### PR TITLE
feat(mip): implement machine initialization procedure

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+build/
+.git/
+*.o
+*.a
+docker-compose.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 build
 .vscode
+.DS_Store
+.idea

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,25 +8,22 @@ find_program(VALGRIND_EXECUTABLE NAMES valgrind)
 
 if (ENABLE_COVERAGE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage -O0")
-
     set(MEMORYCHECK_COMMAND "${VALGRIND_EXECUTABLE}")
     set(MEMORYCHECK_COMMAND_OPTIONS "--tool=memcheck --leak-check=full --track-fds=yes --error-exitcode=1")
 
     add_custom_target(
         memcheck
-
         COMMAND ctest -T memcheck
         COMMAND python3 ${CMAKE_SOURCE_DIR}/tests/lookup_wrong_fds.py ${CMAKE_CURRENT_BINARY_DIR}/Testing/Temporary
     )
+
     add_custom_target(
         coverage
-
         COMMAND lcov --directory . --zerocounters --rc branch_coverage=1
         COMMAND ctest
-        
-        COMMAND lcov --capture --directory . --output-file coverage.info --ignore-errors mismatch --rc branch_coverage=1
-        COMMAND lcov --remove coverage.info '/usr/*' '*test*' --output-file coverage_filtered.info --rc branch_coverage=1
 
+        COMMAND lcov --capture --directory . --output-file coverage.info --ignore-errors mismatch --rc branch_coverage=1
+        COMMAND lcov --remove coverage.info '/usr/*' '*test*' --output-file coverage_filtered.info --rc branch_coverage=1 --ignore-errors unused
         COMMAND genhtml coverage_filtered.info --output-directory html_report --rc branch_coverage=1
     )
 endif()
@@ -43,28 +40,37 @@ include_directories(${ProtobufIncludePath})
 #############################################################
 
 SET(VNET_SOURCE_FILES
+        src/common/socket_utils.cpp
         src/protocol/header.cpp
         src/protocol/types.cpp
-        
+        src/protocol/dispatch.cpp
+
         src/netqueue/element.cpp
         src/netqueue/netqueue.cpp
         src/netqueue/handler.cpp)
 
 add_library(vnet STATIC ${VNET_SOURCE_FILES})
+target_link_libraries(vnet PUBLIC vnet_proto)
 target_link_libraries(vnet PRIVATE gcov)
 target_include_directories(vnet PUBLIC include)
+
+#############################################################
+######################## EXECUTABLES ########################
+#############################################################
+
+add_subdirectory(src/conductor)
+add_subdirectory(src/switch)
+add_subdirectory(src/agent)
 
 #############################################################
 ######################## GOOGLE TEST ########################
 #############################################################
 
 include(FetchContent)
-
 FetchContent_Declare(
     googletest
     URL https://github.com/google/googletest/archive/refs/tags/v1.17.0.zip
 )
 FetchContent_MakeAvailable(googletest)
-
 enable_testing()
 add_subdirectory(tests)

--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -1,0 +1,24 @@
+FROM ubuntu:24.04 AS builder
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    cmake \
+    protobuf-compiler \
+    libprotobuf-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY . /app
+
+RUN cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && \
+    cmake --build build --target agent -- -j$(nproc)
+
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libprotobuf32t64 bash \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/build/agent /usr/local/bin/agent
+
+CMD ["/usr/local/bin/agent"]

--- a/docker/Dockerfile.conductor
+++ b/docker/Dockerfile.conductor
@@ -1,0 +1,24 @@
+FROM ubuntu:24.04 AS builder
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    cmake \
+    protobuf-compiler \
+    libprotobuf-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY . /app
+
+RUN cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && \
+    cmake --build build --target conductor -- -j$(nproc)
+
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libprotobuf32t64 bash \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/build/conductor /usr/local/bin/conductor
+
+CMD ["/usr/local/bin/conductor"]

--- a/docker/Dockerfile.switch
+++ b/docker/Dockerfile.switch
@@ -1,0 +1,24 @@
+FROM ubuntu:24.04 AS builder
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    cmake \
+    protobuf-compiler \
+    libprotobuf-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY . /app
+
+RUN cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && \
+    cmake --build build --target switch -- -j$(nproc)
+
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libprotobuf32t64 bash \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/build/switch /usr/local/bin/switch
+
+CMD ["/usr/local/bin/switch"]

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -1,0 +1,32 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y \
+        build-essential \
+        cmake \
+        ninja-build \
+        python3 \
+        python3-pip \
+        git \
+        wget \
+        curl \
+        pkg-config \
+        libpthread-stubs0-dev \
+        protobuf-compiler \
+        libprotobuf-dev \
+        libgtest-dev \
+        libgmock-dev \
+        lcov \
+        gcovr \
+        && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /vnet
+COPY . /vnet
+
+RUN mkdir -p build
+WORKDIR /vnet/build
+RUN cmake -B . -S .. -GNinja -DENABLE_COVERAGE=ON -DBUILD_TESTS=ON && ninja
+
+ENTRYPOINT ["ctest", "--output-on-failure", "-j4"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,122 @@
+services:
+  conductor:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.conductor
+    container_name: vnet-conductor
+    networks: [vnet]
+    healthcheck:
+      test: ["CMD", "bash", "-c", "timeout 1 bash -c 'echo > /dev/tcp/127.0.0.1/5000' || exit 1"]
+      interval: 3s
+      retries: 10
+      start_period: 5s
+    command: ["/usr/local/bin/conductor"]
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    restart: unless-stopped
+
+  switch1:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.switch
+    container_name: vnet-switch1
+    networks: [vnet]
+    depends_on:
+      conductor:
+        condition: service_healthy
+    environment:
+      - CONDUCTOR_IP=vnet-conductor
+      - CONDUCTOR_PORT=5000
+    command: ["/usr/local/bin/switch", "switch1", "authkey1", "6000"]
+    healthcheck:
+      test: ["CMD", "bash", "-c", "timeout 1 bash -c 'echo > /dev/tcp/127.0.0.1/6000' || exit 1"]
+      interval: 3s
+      retries: 10
+      start_period: 5s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    restart: unless-stopped
+
+  switch2:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.switch
+    container_name: vnet-switch2
+    networks: [vnet]
+    depends_on:
+      conductor:
+        condition: service_healthy
+    environment:
+      - CONDUCTOR_IP=vnet-conductor
+      - CONDUCTOR_PORT=5000
+    command: ["/usr/local/bin/switch", "switch2", "authkey2", "6001"]
+    healthcheck:
+      test: ["CMD", "bash", "-c", "timeout 1 bash -c 'echo > /dev/tcp/127.0.0.1/6001' || exit 1"]
+      interval: 3s
+      retries: 10
+      start_period: 5s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    restart: unless-stopped
+
+  switch3:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.switch
+    container_name: vnet-switch3
+    networks: [vnet]
+    depends_on:
+      conductor:
+        condition: service_healthy
+    environment:
+      - CONDUCTOR_IP=vnet-conductor
+      - CONDUCTOR_PORT=5000
+    command: ["/usr/local/bin/switch", "switch3", "authkey3", "6002"]
+    healthcheck:
+      test: ["CMD", "bash", "-c", "timeout 1 bash -c 'echo > /dev/tcp/127.0.0.1/6002' || exit 1"]
+      interval: 3s
+      retries: 10
+      start_period: 5s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    restart: unless-stopped
+
+  agent:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.agent
+    container_name: vnet-agent
+    networks: [vnet]
+    depends_on:
+      switch1:
+        condition: service_healthy
+      switch2:
+        condition: service_healthy
+      switch3:
+        condition: service_healthy
+    environment:
+      - CONDUCTOR_IP=vnet-conductor
+      - CONDUCTOR_PORT=5000
+    command: ["/usr/local/bin/agent", "agent1", "agentkey1"]
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    restart: unless-stopped
+
+networks:
+  vnet:
+    driver: bridge

--- a/docker/mip.proto
+++ b/docker/mip.proto
@@ -1,0 +1,33 @@
+syntax = "proto3";
+
+package vnet.protocol.mip;
+
+message PacketSwitchMIP {
+    string name     = 1;
+    string auth_key = 2;
+    string network  = 3;
+    
+    port = 4;
+}
+message PacketAgentMIP {
+    string name     = 1;
+    string auth_key = 2;
+    string network  = 3;
+}
+
+
+message PacketConnectToSwitch {
+    string  switch_name = 1;
+    fixed32 switch_ipv4 = 2;
+
+    fixed64 connection_token = 3;
+}
+message PacketAgentConnectionToken {
+    string agent_name = 1;
+
+    fixed64 connection_token = 2;
+}
+message PacketAuthConnectToSwitch {
+    fixed64 connection_token = 2;
+}
+message PacketConnectionAccepted {}

--- a/include/common/config.h
+++ b/include/common/config.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <string>
+#include <cstdint>
+
+/**
+ * @brief Generic machine configuration (IP + port).
+ */
+struct MachineConfig {
+    std::string ip;   /**< The IP address of the conductor. */
+    uint16_t port;    /**< The port number of the conductor. */
+};

--- a/include/common/socket_utils.h
+++ b/include/common/socket_utils.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <cstddef>
+#include "common/config.h"
+#include "vnet/protocol/header.hpp"
+#include <google/protobuf/message.h>
+
+/**
+ * @brief Connect to another machine using MachineConfig (blocking).
+ * @return socket fd on success, -1 on failure.
+ */
+int connect_to(const MachineConfig& mc);
+
+/**
+ * @brief Set a file descriptor to non-blocking mode.
+ * @return true on success.
+ */
+bool set_nonblocking(int fd);
+
+/**
+ * @brief Read exactly n bytes from a socket (blocking).
+ */
+bool read_n_bytes(int sock, void* buffer, size_t n);
+
+/**
+ * @brief Write exactly n bytes to a socket.
+ *        Handles EAGAIN for non-blocking fds via retry.
+ */
+bool write_n_bytes(int sock, const void* buffer, size_t n);
+
+/**
+ * @brief Send a protobuf message with the 6-byte packet header.
+ *
+ * Wire format: [4-byte payload_size (network order)]
+ *              [2-byte packet_type  (network order)]
+ *              [protobuf payload bytes]
+ *
+ * payload_size = sizeof(packet_type) + protobuf_size
+ * but we store it as just protobuf_size since the header
+ * struct stores both fields and NetQueue reads header first.
+ *
+ * IMPORTANT: payload_size in the header is the number of bytes
+ * AFTER the 6-byte header, matching NetQueue::process().
+ */
+bool send_protobuf_packet(int sock, vnet::protocol::PacketType type,
+                          const google::protobuf::Message& msg);
+
+/**
+ * @brief Read a protobuf message with the 6-byte packet header (blocking).
+ *
+ * Reads the full header, verifies the packet type, then reads
+ * and parses the protobuf payload.
+ *
+ * @param expected_type  If set to a valid type, the function will
+ *                       fail if the received type doesn't match.
+ * @param received_type  If non-null, receives the actual packet type.
+ */
+bool read_protobuf_packet(int sock, vnet::protocol::PacketType expected_type,
+                          google::protobuf::Message& msg);
+
+/**
+ * @brief Read a packet header and payload, returning the type.
+ *        Useful when you don't know the packet type in advance.
+ *
+ * @param type     Receives the packet type.
+ * @param buffer   Receives the payload bytes.
+ * @param buf_size Receives the payload size.
+ * @return true on success.
+ */
+bool read_raw_packet(int sock, vnet::protocol::PacketType& type,
+                     std::vector<char>& buffer);
+
+/**
+ * @brief Send a heartbeat (header-only, zero-length payload).
+ */
+bool send_heartbeat(int sock);
+
+/**
+ * @brief Convert a network-order uint32_t IPv4 to string.
+ */
+std::string ipv4_to_string(uint32_t ipv4);
+
+/**
+ * @brief Convert an IPv4 string to network-order uint32_t.
+ */
+uint32_t string_to_ipv4(const std::string& ip);

--- a/include/vnet/netqueue/handler.hpp
+++ b/include/vnet/netqueue/handler.hpp
@@ -41,14 +41,16 @@ namespace vnet::netqueue {
         size_t ip_buffer_size;
     };
 
-    void doNothingOnClose       (close_data  close_content);
-    void doNothingOnSocketReady (socket_data data);
-    void doNothingOnTunReady    (tun_data    data);
+    void doNothingOnClose       (void* ptr_data, close_data  close_content);
+    void doNothingOnSocketReady (void* ptr_data, socket_data data);
+    void doNothingOnTunReady    (void* ptr_data, tun_data    data);
 
     struct NetworkQueueHandler {
-        void (*onClose)       (close_data  close_content) = &doNothingOnClose;
-        void (*onSocketReady) (socket_data data)          = &doNothingOnSocketReady;
-        void (*onTunReady)    (tun_data    data)          = &doNothingOnTunReady;
+        void (*onClose)       (void* ptr_data, close_data  close_content) = &doNothingOnClose;
+        void (*onSocketReady) (void* ptr_data, socket_data data)          = &doNothingOnSocketReady;
+        void (*onTunReady)    (void* ptr_data, tun_data    data)          = &doNothingOnTunReady;
+        
+        void* ptr_data = nullptr;
     };
 
 }

--- a/include/vnet/protocol/dispatch.hpp
+++ b/include/vnet/protocol/dispatch.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "vnet/netqueue/handler.hpp"
+#include "mip.pb.h"
+
+namespace vnet::protocol {
+
+    struct Dispatch {
+    public:
+        void onSocketReady (netqueue::socket_data data);
+
+        virtual void onClose    (netqueue::close_data close_content);
+        virtual void onTunReady (netqueue::tun_data   data);
+
+        virtual void onHeartbeat (netqueue::socket_data data);
+
+        /** Machine Initialization Procedure */
+        virtual void onSwitchMIP (netqueue::socket_data data, mip::PacketSwitchMIP &packet);
+        virtual void onAgentMIP  (netqueue::socket_data data, mip::PacketAgentMIP  &packet);
+
+        virtual void onConnectToSwitch      (netqueue::socket_data data, mip::PacketConnectToSwitch      &packet);
+        virtual void onAuthConnectToSwitch  (netqueue::socket_data data, mip::PacketAuthConnectToSwitch  &packet);
+        virtual void onAgentConnectionToken (netqueue::socket_data data, mip::PacketAgentConnectionToken &packet);
+        virtual void onConnectionAccepted   (netqueue::socket_data data, mip::PacketConnectionAccepted   &packet);
+
+        /** Reconnection */
+        virtual void onAgentMRP (netqueue::socket_data data, mip::PacketAgentMRP &packet);
+
+        virtual ~Dispatch() = default;
+    };
+
+    netqueue::NetworkQueueHandler makeNetworkQueueHandler (Dispatch *dispatch);
+};

--- a/include/vnet/protocol/types.hpp
+++ b/include/vnet/protocol/types.hpp
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include <cstdint>
@@ -7,7 +6,17 @@ namespace vnet::protocol {
     using uint_packet_t = uint16_t;
 
     enum PacketType : uint16_t {
+        HEARTBEAT = 0,
 
+        SWITCH_MIP,
+        AGENT_MIP,
+
+        CONNECT_TO_SWITCH,
+        AGENT_CONNECTION_TOKEN,
+        AUTH_CONNECT_TO_SWITCH,
+        CONNECTION_ACCEPTED,
+
+        AGENT_MRP
     };
 
     PacketType    ntoh_packet_type (uint_packet_t type);

--- a/proto/CMakeLists.txt
+++ b/proto/CMakeLists.txt
@@ -1,10 +1,14 @@
+# CMakeLists.txt for proto directory
+
 find_package(Protobuf REQUIRED)
 
-protobuf_generate_cpp(
-    PROTO_SRC
-    PROTO_HEADER
-    message.proto
+protobuf_generate_cpp(PROTO_SRC PROTO_HDR mip.proto)
+
+add_library(vnet_proto STATIC ${PROTO_SRC} ${PROTO_HDR})
+
+target_include_directories(vnet_proto PUBLIC
+    ${CMAKE_CURRENT_BINARY_DIR}
+    ${Protobuf_INCLUDE_DIRS}
 )
 
-add_library(vnet_proto ${PROTO_HEADER} ${PROTO_SRC})
-target_link_libraries(vnet_proto PRIVATE ${PROTOBUF_LIBRARIES})
+target_link_libraries(vnet_proto PUBLIC protobuf::libprotobuf)

--- a/proto/message.proto
+++ b/proto/message.proto
@@ -1,7 +1,0 @@
-syntax = "proto3";
-
-package sample.message;
-
-message Message {
-    repeated int32 id = 1;
-}

--- a/proto/mip.proto
+++ b/proto/mip.proto
@@ -1,0 +1,42 @@
+syntax = "proto3";
+
+package vnet.protocol.mip;
+
+message PacketSwitchMIP {
+    string name     = 1;
+    string auth_key = 2;
+    string network  = 3;
+
+    uint32 port = 4;
+}
+
+message PacketAgentMIP {
+    string name     = 1;
+    string auth_key = 2;
+    string network  = 3;
+}
+
+message PacketConnectToSwitch {
+    string  switch_name = 1;
+    fixed32 switch_ipv4 = 2;
+
+    fixed64 connection_token = 3;
+
+    uint32  switch_port = 4;
+}
+
+message PacketAgentConnectionToken {
+    string  agent_name       = 1;
+    fixed64 connection_token = 2;
+}
+
+message PacketAuthConnectToSwitch {
+    fixed64 connection_token = 1;
+}
+
+message PacketConnectionAccepted {}
+
+message PacketAgentMRP {
+    string name     = 1;
+    string auth_key = 2;
+}

--- a/src/agent/CMakeLists.txt
+++ b/src/agent/CMakeLists.txt
@@ -1,0 +1,9 @@
+# CMakeLists.txt for agent
+
+add_executable(agent setup.cpp)
+
+set_target_properties(agent PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+)
+
+target_link_libraries(agent PRIVATE vnet)

--- a/src/agent/setup.cpp
+++ b/src/agent/setup.cpp
@@ -1,0 +1,248 @@
+#include <iostream>
+#include <string>
+#include <chrono>
+#include <csignal>
+#include <cstring>
+#include <thread>
+
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <netinet/tcp.h>
+#include <unistd.h>
+
+#include "mip.pb.h"
+#include "common/config.h"
+#include "common/socket_utils.h"
+#include "vnet/protocol/dispatch.hpp"
+#include "vnet/netqueue/netqueue.hpp"
+
+using namespace vnet::protocol;
+using namespace vnet::netqueue;
+using clk = std::chrono::steady_clock;
+
+static const std::chrono::seconds HEARTBEAT_INTERVAL {30};
+static const int MAX_CONNECT_RETRIES  = 20;
+static const int RETRY_DELAY_MS       = 2000;
+
+static volatile sig_atomic_t g_running = 1;
+static void on_signal(int) { g_running = 0; }
+
+// ---------------------------------------------------------------------------
+//  Connection metadata
+// ---------------------------------------------------------------------------
+
+enum class ConnRole { CONDUCTOR, SWITCH };
+
+struct ConnInfo {
+    ConnRole role;
+    int      fd = -1;
+    clk::time_point last_hb_sent = clk::now();
+};
+
+struct AgentState {
+    ConnInfo* conductor = nullptr;
+    ConnInfo* sw        = nullptr;
+};
+static AgentState g_state;
+
+// ---------------------------------------------------------------------------
+//  Dispatch — handles packets arriving via NetQueue
+// ---------------------------------------------------------------------------
+
+struct AgentDispatch : public Dispatch {
+
+    void onHeartbeat(socket_data) override {}
+
+    /* 
+     * After initial MIP the control-plane is mostly idle.
+     * Future extensions (DNS queries, IP group updates) go here.
+     */
+
+    void onClose(close_data data) override {
+        auto* info = static_cast<ConnInfo*>(data.ptr_data);
+        if (!info) return;
+
+        std::cout << "[Agent] Connection closed: fd=" << data.fd
+                  << " role=" << (int)info->role << "\n";
+
+        if (info == g_state.conductor) g_state.conductor = nullptr;
+        if (info == g_state.sw)        g_state.sw        = nullptr;
+
+        delete info;
+    }
+};
+
+// ---------------------------------------------------------------------------
+//  Heartbeat sender
+// ---------------------------------------------------------------------------
+
+static void send_heartbeats() {
+    auto now = clk::now();
+    auto try_hb = [&](ConnInfo* c) {
+        if (c && c->fd >= 0 && now - c->last_hb_sent >= HEARTBEAT_INTERVAL) {
+            send_heartbeat(c->fd);
+            c->last_hb_sent = now;
+        }
+    };
+
+    try_hb(g_state.conductor);
+    try_hb(g_state.sw);
+}
+
+// ---------------------------------------------------------------------------
+//  connect_to with retries (waits for the target to be up)
+// ---------------------------------------------------------------------------
+
+static int connect_with_retry(const MachineConfig& mc, const char* label) {
+    for (int attempt = 1; attempt <= MAX_CONNECT_RETRIES; attempt++) {
+        int fd = connect_to(mc);
+        if (fd >= 0) return fd;
+
+        std::cerr << "[Agent] " << label << " attempt " << attempt
+                  << "/" << MAX_CONNECT_RETRIES << " failed, retrying...\n";
+        std::this_thread::sleep_for(std::chrono::milliseconds(RETRY_DELAY_MS));
+    }
+    return -1;
+}
+
+// ---------------------------------------------------------------------------
+//  Main — runs the sequential MIP then enters the event loop
+// ---------------------------------------------------------------------------
+
+int main(int argc, char** argv) {
+    GOOGLE_PROTOBUF_VERIFY_VERSION;
+    std::cout << std::unitbuf;
+    std::cerr << std::unitbuf;
+    signal(SIGINT,  on_signal);
+    signal(SIGTERM, on_signal);
+    signal(SIGPIPE, SIG_IGN);
+
+    if (argc != 3) {
+        std::cerr << "Usage: ./agent <name> <auth_key>\n";
+        return 1;
+    }
+
+    std::string agent_name = argv[1];
+    std::string auth_key   = argv[2];
+
+    const char* cdt_ip_env   = std::getenv("CONDUCTOR_IP");
+    const char* cdt_port_env = std::getenv("CONDUCTOR_PORT");
+    if (!cdt_ip_env || !cdt_port_env) {
+        std::cerr << "[Agent] CONDUCTOR_IP and CONDUCTOR_PORT must be set\n";
+        return 1;
+    }
+
+    MachineConfig conductor_cfg {
+        cdt_ip_env,
+        static_cast<uint16_t>(std::stoi(cdt_port_env))
+    };
+
+    // ===================================================================
+    //  STEP 1 — Connect to conductor and send Agent MIP
+    // ===================================================================
+    std::cout << "[Agent] Connecting to conductor "
+              << conductor_cfg.ip << ":" << conductor_cfg.port << " ...\n";
+
+    int cdt_sock = connect_with_retry(conductor_cfg, "conductor");
+    if (cdt_sock < 0) {
+        std::cerr << "[Agent] Could not reach conductor\n";
+        return 1;
+    }
+
+    mip::PacketAgentMIP mip_pkt;
+    mip_pkt.set_name(agent_name);
+    mip_pkt.set_auth_key(auth_key);
+    mip_pkt.set_network("vnet.internal");
+
+    if (!send_protobuf_packet(cdt_sock, PacketType::AGENT_MIP, mip_pkt)) {
+        std::cerr << "[Agent] Failed to send MIP\n";
+        close(cdt_sock);
+        return 1;
+    }
+
+    // ===================================================================
+    //  STEP 2 — Receive switch assignment
+    // ===================================================================
+    mip::PacketConnectToSwitch assignment;
+    if (!read_protobuf_packet(cdt_sock, PacketType::CONNECT_TO_SWITCH, assignment)) {
+        std::cerr << "[Agent] Did not receive switch assignment\n";
+        close(cdt_sock);
+        return 1;
+    }
+
+    std::string sw_ip   = ipv4_to_string(assignment.switch_ipv4());
+    uint16_t    sw_port = static_cast<uint16_t>(assignment.switch_port());
+
+    std::cout << "[Agent] Assigned to switch " << assignment.switch_name()
+              << " @ " << sw_ip << ":" << sw_port << "\n";
+
+    // ===================================================================
+    //  STEP 3 — Connect to switch and authenticate
+    // ===================================================================
+    MachineConfig sw_cfg { sw_ip, sw_port };
+
+    int sw_sock = connect_with_retry(sw_cfg, "switch");
+    if (sw_sock < 0) {
+        std::cerr << "[Agent] Cannot reach assigned switch\n";
+        close(cdt_sock);
+        return 1;
+    }
+
+    mip::PacketAuthConnectToSwitch auth_pkt;
+    auth_pkt.set_connection_token(assignment.connection_token());
+
+    if (!send_protobuf_packet(sw_sock, PacketType::AUTH_CONNECT_TO_SWITCH, auth_pkt)) {
+        std::cerr << "[Agent] Failed to send auth to switch\n";
+        close(sw_sock);
+        close(cdt_sock);
+        return 1;
+    }
+
+    mip::PacketConnectionAccepted ack;
+    if (!read_protobuf_packet(sw_sock, PacketType::CONNECTION_ACCEPTED, ack)) {
+        std::cerr << "[Agent] Switch did not accept connection\n";
+        close(sw_sock);
+        close(cdt_sock);
+        return 1;
+    }
+
+    std::cout << "[Agent] Authenticated with switch "
+              << assignment.switch_name() << "!\n";
+
+    // ===================================================================
+    //  STEP 4 — Switch both fds to non-blocking, enter event loop
+    // ===================================================================
+    set_nonblocking(cdt_sock);
+    set_nonblocking(sw_sock);
+
+    int flag = 1;
+    setsockopt(cdt_sock, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag));
+    setsockopt(sw_sock,  IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag));
+
+    AgentDispatch dispatch;
+    NetworkQueueHandler handler = makeNetworkQueueHandler(&dispatch);
+    NetQueue queue(handler, /*epoll_timeout_ms=*/200);
+
+    auto* cdt_info = new ConnInfo();
+    cdt_info->role = ConnRole::CONDUCTOR;
+    cdt_info->fd   = cdt_sock;
+    g_state.conductor = cdt_info;
+    queue.put_sck(cdt_sock, cdt_info);
+
+    auto* sw_info = new ConnInfo();
+    sw_info->role = ConnRole::SWITCH;
+    sw_info->fd   = sw_sock;
+    g_state.sw = sw_info;
+    queue.put_sck(sw_sock, sw_info);
+
+    std::cout << "[Agent] Entering event loop.\n";
+
+    while (g_running) {
+        queue.wait_and_process();
+        send_heartbeats();
+    }
+
+    std::cout << "[Agent] Shutting down.\n";
+    google::protobuf::ShutdownProtobufLibrary();
+    return 0;
+}

--- a/src/common/socket_utils.cpp
+++ b/src/common/socket_utils.cpp
@@ -1,0 +1,193 @@
+#include <unistd.h>
+#include <fcntl.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <sys/socket.h>
+#include <cstring>
+#include <iostream>
+#include <vector>
+#include <stdexcept>
+
+#include "common/config.h"
+#include "common/socket_utils.h"
+#include "vnet/protocol/header.hpp"
+
+using namespace vnet::protocol;
+
+// ---------------------------------------------------------------------------
+//  Low-level helpers
+// ---------------------------------------------------------------------------
+
+int connect_to(const MachineConfig& mc) {
+    struct addrinfo hints{}, *result = nullptr;
+    hints.ai_family   = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+
+    std::string port_str = std::to_string(mc.port);
+
+    int rc = getaddrinfo(mc.ip.c_str(), port_str.c_str(), &hints, &result);
+    if (rc != 0 || !result) {
+        if (result) freeaddrinfo(result);
+        return -1;
+    }
+
+    int sock = socket(result->ai_family, result->ai_socktype, result->ai_protocol);
+    if (sock < 0) {
+        freeaddrinfo(result);
+        return -1;
+    }
+
+    if (connect(sock, result->ai_addr, result->ai_addrlen) < 0) {
+        close(sock);
+        freeaddrinfo(result);
+        return -1;
+    }
+
+    freeaddrinfo(result);
+    return sock;
+}
+
+bool set_nonblocking(int fd) {
+    int flags = fcntl(fd, F_GETFL, 0);
+    if (flags < 0) return false;
+    return fcntl(fd, F_SETFL, flags | O_NONBLOCK) >= 0;
+}
+
+bool write_n_bytes(int sock, const void* buffer, size_t n) {
+    size_t total = 0;
+    const char* ptr = static_cast<const char*>(buffer);
+    while (total < n) {
+        ssize_t r = write(sock, ptr + total, n - total);
+        if (r < 0) {
+            if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
+                usleep(200);          // brief yield, then retry
+                continue;
+            }
+            return false;
+        }
+        if (r == 0) return false;
+        total += r;
+    }
+    return true;
+}
+
+bool read_n_bytes(int sock, void* buffer, size_t n) {
+    size_t total = 0;
+    char* ptr = static_cast<char*>(buffer);
+    while (total < n) {
+        ssize_t r = read(sock, ptr + total, n - total);
+        if (r < 0) {
+            if (errno == EINTR) continue;
+            return false;               // EAGAIN = not ready, treat as error in blocking context
+        }
+        if (r == 0) return false;       // EOF
+        total += r;
+    }
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+//  Packet framing — matches the 6-byte PacketHeader used by NetQueue
+//
+//  Wire layout:
+//    [uint32_t  payload_size ]   4 bytes, network order
+//    [uint16_t  packet_type  ]   2 bytes, network order
+//    [          protobuf body]   payload_size bytes
+//
+//  payload_size is the number of bytes AFTER the 6-byte header,
+//  which is exactly the serialized protobuf size.
+// ---------------------------------------------------------------------------
+
+bool send_protobuf_packet(int sock, PacketType type,
+                          const google::protobuf::Message& msg) {
+    std::string body;
+    if (!msg.SerializeToString(&body)) return false;
+
+    PacketHeader hdr(static_cast<uint32_t>(body.size()), type);
+
+    // Write header (6 bytes)
+    if (!write_n_bytes(sock, &hdr, PACKET_HEADER_SIZE)) return false;
+
+    // Write protobuf payload
+    if (!body.empty()) {
+        if (!write_n_bytes(sock, body.data(), body.size())) return false;
+    }
+
+    return true;
+}
+
+bool read_protobuf_packet(int sock, PacketType expected_type,
+                          google::protobuf::Message& msg) {
+    // Read 6-byte header
+    PacketHeader hdr;
+    if (!read_n_bytes(sock, &hdr, PACKET_HEADER_SIZE)) return false;
+
+    PacketType type = hdr.get_packet_type();
+    uint32_t   len  = hdr.get_payload_size();
+
+    // Skip heartbeats transparently — keep reading until we get the
+    // expected type (or any non-heartbeat).
+    while (type == PacketType::HEARTBEAT) {
+        // Heartbeat has zero-length payload, but honour the field anyway
+        if (len > 0) {
+            std::vector<char> skip(len);
+            if (!read_n_bytes(sock, skip.data(), len)) return false;
+        }
+        if (!read_n_bytes(sock, &hdr, PACKET_HEADER_SIZE)) return false;
+        type = hdr.get_packet_type();
+        len  = hdr.get_payload_size();
+    }
+
+    if (type != expected_type) return false;
+
+    if (len == 0) {
+        msg.Clear();
+        return true;
+    }
+
+    std::vector<char> buf(len);
+    if (!read_n_bytes(sock, buf.data(), len)) return false;
+
+    return msg.ParseFromArray(buf.data(), buf.size());
+}
+
+bool read_raw_packet(int sock, PacketType& type, std::vector<char>& buffer) {
+    PacketHeader hdr;
+    if (!read_n_bytes(sock, &hdr, PACKET_HEADER_SIZE)) return false;
+
+    type          = hdr.get_packet_type();
+    uint32_t len  = hdr.get_payload_size();
+
+    buffer.resize(len);
+    if (len > 0) {
+        if (!read_n_bytes(sock, buffer.data(), len)) return false;
+    }
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+//  Heartbeat — header only, zero-length payload
+// ---------------------------------------------------------------------------
+
+bool send_heartbeat(int sock) {
+    PacketHeader hdr(0, PacketType::HEARTBEAT);
+    return write_n_bytes(sock, &hdr, PACKET_HEADER_SIZE);
+}
+
+// ---------------------------------------------------------------------------
+//  IPv4 conversion helpers
+// ---------------------------------------------------------------------------
+
+std::string ipv4_to_string(uint32_t ipv4) {
+    char buf[INET_ADDRSTRLEN];
+    inet_ntop(AF_INET, &ipv4, buf, INET_ADDRSTRLEN);
+    return std::string(buf);
+}
+
+uint32_t string_to_ipv4(const std::string& ip) {
+    uint32_t addr = 0;
+    if (inet_pton(AF_INET, ip.c_str(), &addr) != 1) {
+        throw std::runtime_error("Invalid IPv4 string: " + ip);
+    }
+    return addr;
+}

--- a/src/conductor/CMakeLists.txt
+++ b/src/conductor/CMakeLists.txt
@@ -1,0 +1,9 @@
+# CMakeLists.txt for conductor
+
+add_executable(conductor setup.cpp)
+
+set_target_properties(conductor PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+)
+
+target_link_libraries(conductor PRIVATE vnet)

--- a/src/conductor/setup.cpp
+++ b/src/conductor/setup.cpp
@@ -1,0 +1,318 @@
+#include <iostream>
+#include <vector>
+#include <unordered_map>
+#include <mutex>
+#include <chrono>
+#include <random>
+#include <algorithm>
+#include <csignal>
+#include <cstring>
+
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <netinet/tcp.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#include "mip.pb.h"
+#include "common/config.h"
+#include "common/socket_utils.h"
+#include "vnet/protocol/dispatch.hpp"
+#include "vnet/netqueue/netqueue.hpp"
+
+using namespace vnet::protocol;
+using namespace vnet::netqueue;
+using clk = std::chrono::steady_clock;
+
+// ---------------------------------------------------------------------------
+//  Constants
+// ---------------------------------------------------------------------------
+
+static const uint16_t            LISTEN_PORT         = 5000;
+static const int                 LISTEN_BACKLOG      = 64;
+static const std::chrono::seconds HEARTBEAT_INTERVAL {30};
+
+static volatile sig_atomic_t g_running = 1;
+static void on_signal(int) { g_running = 0; }
+
+// ---------------------------------------------------------------------------
+//  Per-connection metadata stored in NetworkElement::ptr
+// ---------------------------------------------------------------------------
+
+enum class Role { UNKNOWN, SWITCH_CONN, AGENT_CONN };
+
+struct ConnInfo {
+    Role        role = Role::UNKNOWN;
+    std::string name;
+    std::string auth_key;
+    std::string network;
+
+    /* Switch-only fields */
+    uint16_t    sw_port = 0;
+    uint32_t    sw_ipv4 = 0;    // network-order peer IP
+
+    int         fd = -1;
+    clk::time_point last_hb_sent = clk::now();
+};
+
+// ---------------------------------------------------------------------------
+//  Conductor state
+// ---------------------------------------------------------------------------
+
+struct ConductorState {
+    std::vector<ConnInfo*> switches;
+    std::vector<ConnInfo*> agents;
+
+    size_t rr_index = 0;
+
+    std::mt19937_64 rng{std::random_device{}()};
+
+    uint64_t generate_token() {
+        return rng();
+    }
+
+    ConnInfo* pick_switch(const std::string& agent_network) {
+        if (switches.empty()) return nullptr;
+
+        /* 
+         * Spec: the conductor should ensure the agent can theoretically
+         * reach the switch (same network OR switch is "::internet").
+         * We also round-robin for load balancing.
+         */
+        size_t start = rr_index;
+        for (size_t i = 0; i < switches.size(); i++) {
+            size_t idx = (start + i) % switches.size();
+            ConnInfo* sw = switches[idx];
+
+            bool reachable =
+                sw->network == agent_network ||
+                sw->network == "::internet";
+
+            if (reachable) {
+                rr_index = idx + 1;
+                return sw;
+            }
+        }
+        // Fallback: round-robin without network check
+        ConnInfo* sw = switches[start % switches.size()];
+        rr_index = start + 1;
+        return sw;
+    }
+
+    void remove_switch(ConnInfo* info) {
+        switches.erase(
+            std::remove(switches.begin(), switches.end(), info),
+            switches.end());
+    }
+    void remove_agent(ConnInfo* info) {
+        agents.erase(
+            std::remove(agents.begin(), agents.end(), info),
+            agents.end());
+    }
+};
+
+static ConductorState g_state;
+
+// ---------------------------------------------------------------------------
+//  Dispatch subclass — handles packets that arrive on the NetQueue
+// ---------------------------------------------------------------------------
+
+struct ConductorDispatch : public Dispatch {
+
+    void onSwitchMIP(socket_data data, mip::PacketSwitchMIP& pkt) override {
+        auto* info   = static_cast<ConnInfo*>(data.ptr_data);
+        info->role     = Role::SWITCH_CONN;
+        info->name     = pkt.name();
+        info->auth_key = pkt.auth_key();
+        info->network  = pkt.network();
+        info->sw_port  = static_cast<uint16_t>(pkt.port());
+        info->fd       = data.fd;
+
+        // Obtain the switch's IP from the TCP peer address
+        sockaddr_in peer{};
+        socklen_t plen = sizeof(peer);
+        if (getpeername(data.fd, (sockaddr*)&peer, &plen) == 0) {
+            info->sw_ipv4 = peer.sin_addr.s_addr;   // already network order
+        }
+
+        g_state.switches.push_back(info);
+
+        std::cout << "[Conductor] Switch registered: " << info->name
+                  << " @ " << ipv4_to_string(info->sw_ipv4)
+                  << ":" << info->sw_port
+                  << " (network=" << info->network << ")\n";
+    }
+
+    void onAgentMIP(socket_data data, mip::PacketAgentMIP& pkt) override {
+        auto* info   = static_cast<ConnInfo*>(data.ptr_data);
+        info->role     = Role::AGENT_CONN;
+        info->name     = pkt.name();
+        info->auth_key = pkt.auth_key();
+        info->network  = pkt.network();
+        info->fd       = data.fd;
+
+        ConnInfo* sw = g_state.pick_switch(pkt.network());
+        if (!sw) {
+            std::cerr << "[Conductor] No available switch for agent "
+                      << pkt.name() << "\n";
+            return;
+        }
+
+        uint64_t token = g_state.generate_token();
+
+        std::cout << "[Conductor] Agent " << pkt.name()
+                  << " → switch " << sw->name
+                  << " (token=" << token << ")\n";
+
+        // 1) Tell the agent which switch to connect to
+        mip::PacketConnectToSwitch resp;
+        resp.set_switch_name(sw->name);
+        resp.set_switch_ipv4(sw->sw_ipv4);
+        resp.set_connection_token(token);
+        resp.set_switch_port(sw->sw_port);
+        send_protobuf_packet(data.fd, PacketType::CONNECT_TO_SWITCH, resp);
+
+        // 2) Tell the switch to expect this agent (three-party handshake)
+        mip::PacketAgentConnectionToken notify;
+        notify.set_agent_name(pkt.name());
+        notify.set_connection_token(token);
+        send_protobuf_packet(sw->fd, PacketType::AGENT_CONNECTION_TOKEN, notify);
+
+        g_state.agents.push_back(info);
+    }
+
+    void onAgentMRP(socket_data data, mip::PacketAgentMRP& pkt) override {
+        auto* info = static_cast<ConnInfo*>(data.ptr_data);
+        info->role     = Role::AGENT_CONN;
+        info->name     = pkt.name();
+        info->auth_key = pkt.auth_key();
+        info->fd       = data.fd;
+
+        /* 
+         * Reconnection: the agent already has a switch, it just needs
+         * a fresh control-plane socket.  We register the new socket
+         * without redoing the full MIP.
+         */
+        g_state.agents.push_back(info);
+
+        std::cout << "[Conductor] Agent reconnected: " << pkt.name() << "\n";
+    }
+
+    void onHeartbeat(socket_data) override {
+        // nothing to do — the heartbeat kept the connection alive
+    }
+
+    void onClose(close_data data) override {
+        auto* info = static_cast<ConnInfo*>(data.ptr_data);
+        if (!info) return;
+
+        if (info->role != Role::UNKNOWN) {
+            const char* reason_str =
+                data.reason == CLOSE_HANGUP ? "hangup" :
+                data.reason == CLOSE_ERROR  ? "error"  : "epoll";
+
+            std::cout << "[Conductor] Connection closed: " << info->name
+                      << " (fd=" << data.fd
+                      << ", reason=" << reason_str << ")\n";
+        }
+
+        if (info->role == Role::SWITCH_CONN) {
+            g_state.remove_switch(info);
+        } else if (info->role == Role::AGENT_CONN) {
+            g_state.remove_agent(info);
+        }
+
+        delete info;
+    }
+};
+
+// ---------------------------------------------------------------------------
+//  Heartbeat sender — called periodically from the main loop
+// ---------------------------------------------------------------------------
+
+static void send_heartbeats() {
+    auto now = clk::now();
+
+    auto try_hb = [&](ConnInfo* c) {
+        if (now - c->last_hb_sent >= HEARTBEAT_INTERVAL) {
+            send_heartbeat(c->fd);
+            c->last_hb_sent = now;
+        }
+    };
+
+    for (auto* c : g_state.switches) try_hb(c);
+    for (auto* c : g_state.agents)   try_hb(c);
+}
+
+// ---------------------------------------------------------------------------
+//  Main
+// ---------------------------------------------------------------------------
+
+int main() {
+    GOOGLE_PROTOBUF_VERIFY_VERSION;
+    std::cout << std::unitbuf;          // flush after every write (needed for Docker logs)
+    std::cerr << std::unitbuf;
+    signal(SIGINT,  on_signal);
+    signal(SIGTERM, on_signal);
+    signal(SIGPIPE, SIG_IGN);       // don't crash on broken pipe
+
+    // --- Create listener ---
+    int listener = socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
+    if (listener < 0) { perror("socket"); return 1; }
+
+    int optval = 1;
+    setsockopt(listener, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
+
+    sockaddr_in addr{};
+    addr.sin_family      = AF_INET;
+    addr.sin_port        = htons(LISTEN_PORT);
+    addr.sin_addr.s_addr = INADDR_ANY;
+
+    if (bind(listener, (sockaddr*)&addr, sizeof(addr)) < 0) {
+        perror("bind"); return 1;
+    }
+    if (listen(listener, LISTEN_BACKLOG) < 0) {
+        perror("listen"); return 1;
+    }
+
+    std::cout << "[Conductor] Listening on port " << LISTEN_PORT << "\n";
+
+    // --- Create NetQueue ---
+    ConductorDispatch dispatch;
+    NetworkQueueHandler handler = makeNetworkQueueHandler(&dispatch);
+    NetQueue queue(handler, /*epoll_timeout_ms=*/200);
+
+    // --- Event loop ---
+    while (g_running) {
+        // 1. Accept new connections (non-blocking)
+        while (true) {
+            sockaddr_in peer{};
+            socklen_t plen = sizeof(peer);
+            int client = accept4(listener, (sockaddr*)&peer, &plen, SOCK_NONBLOCK);
+            if (client < 0) break;      // EAGAIN or error
+
+            int flag = 1;
+            setsockopt(client, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag));
+
+            auto* info = new ConnInfo();
+            info->fd = client;
+
+            if (!queue.put_sck(client, info)) {
+                std::cerr << "[Conductor] Failed to add fd " << client << " to queue\n";
+                close(client);
+                delete info;
+            }
+        }
+
+        // 2. Process epoll events (reads → dispatch)
+        queue.wait_and_process();
+
+        // 3. Send heartbeats
+        send_heartbeats();
+    }
+
+    close(listener);
+    std::cout << "[Conductor] Shutting down.\n";
+    google::protobuf::ShutdownProtobufLibrary();
+    return 0;
+}

--- a/src/netqueue/handler.cpp
+++ b/src/netqueue/handler.cpp
@@ -3,6 +3,6 @@
 
 using namespace vnet::netqueue;
 
-void vnet::netqueue::doNothingOnClose       (close_data    error_content) {}
-void vnet::netqueue::doNothingOnSocketReady (socket_data data) {}
-void vnet::netqueue::doNothingOnTunReady    (tun_data    data) {}
+void vnet::netqueue::doNothingOnClose       (void* ptr_data, close_data    error_content) {}
+void vnet::netqueue::doNothingOnSocketReady (void* ptr_data, socket_data data) {}
+void vnet::netqueue::doNothingOnTunReady    (void* ptr_data, tun_data    data) {}

--- a/src/netqueue/netqueue.cpp
+++ b/src/netqueue/netqueue.cpp
@@ -120,7 +120,7 @@ void NetQueue::wait_and_process () {
             data.ptr_data = current_element->ptr;
             data.reason = reason;
 
-            handler.onClose(data);
+            handler.onClose(handler.ptr_data, data);
 
             elements_closed.insert(current_element);
 
@@ -190,7 +190,7 @@ void NetQueue::process (NetworkElement* element) {
                 sck_data.payload_size  = header->get_payload_size();
                 sck_data.packet_buffer = element->net_buffer + sizeof(protocol::PacketHeader);
 
-                handler.onSocketReady(sck_data);
+                handler.onSocketReady(handler.ptr_data, sck_data);
 
                 element->net_buffer_used = 0;
                 element->state = SCK_HEADER;
@@ -228,7 +228,7 @@ void NetQueue::process (NetworkElement* element) {
                 data.ip_buffer = element->net_buffer;
                 data.ip_buffer_size = element->net_buffer_used;
                 
-                handler.onTunReady(data);
+                handler.onTunReady(handler.ptr_data, data);
                 
                 element->state = TUN_RECEIVE;
 

--- a/src/protocol/dispatch.cpp
+++ b/src/protocol/dispatch.cpp
@@ -1,0 +1,112 @@
+#include "vnet/protocol/dispatch.hpp"
+
+using namespace vnet::protocol;
+using namespace vnet::netqueue;
+
+// ---------------------------------------------------------------------------
+//  Static C-style callbacks that forward to the Dispatch virtual methods.
+//  These are used by makeNetworkQueueHandler to bridge the C function-pointer
+//  based NetworkQueueHandler to the Dispatch class hierarchy.
+// ---------------------------------------------------------------------------
+
+static void _dispatch_on_close(void* ptr_data, close_data data) {
+    static_cast<Dispatch*>(ptr_data)->onClose(data);
+}
+static void _dispatch_on_socket_ready(void* ptr_data, socket_data data) {
+    static_cast<Dispatch*>(ptr_data)->onSocketReady(data);
+}
+static void _dispatch_on_tun_ready(void* ptr_data, tun_data data) {
+    static_cast<Dispatch*>(ptr_data)->onTunReady(data);
+}
+
+NetworkQueueHandler vnet::protocol::makeNetworkQueueHandler(Dispatch* dispatch) {
+    NetworkQueueHandler handler;
+    handler.ptr_data      = dispatch;
+    handler.onClose       = _dispatch_on_close;
+    handler.onSocketReady = _dispatch_on_socket_ready;
+    handler.onTunReady    = _dispatch_on_tun_ready;
+    return handler;
+}
+
+// ---------------------------------------------------------------------------
+//  Packet dispatch — routes an incoming socket_data to the correct
+//  typed virtual handler based on the packet_type field.
+// ---------------------------------------------------------------------------
+
+void Dispatch::onSocketReady(socket_data data) {
+    switch (data.packet_type) {
+        case HEARTBEAT: {
+            onHeartbeat(data);
+            break;
+        }
+        case SWITCH_MIP: {
+            mip::PacketSwitchMIP packet;
+            if (packet.ParseFromArray(data.packet_buffer, data.payload_size)) {
+                onSwitchMIP(data, packet);
+            }
+            break;
+        }
+        case AGENT_MIP: {
+            mip::PacketAgentMIP packet;
+            if (packet.ParseFromArray(data.packet_buffer, data.payload_size)) {
+                onAgentMIP(data, packet);
+            }
+            break;
+        }
+        case CONNECT_TO_SWITCH: {
+            mip::PacketConnectToSwitch packet;
+            if (packet.ParseFromArray(data.packet_buffer, data.payload_size)) {
+                onConnectToSwitch(data, packet);
+            }
+            break;
+        }
+        case AGENT_CONNECTION_TOKEN: {
+            mip::PacketAgentConnectionToken packet;
+            if (packet.ParseFromArray(data.packet_buffer, data.payload_size)) {
+                onAgentConnectionToken(data, packet);
+            }
+            break;
+        }
+        case AUTH_CONNECT_TO_SWITCH: {
+            mip::PacketAuthConnectToSwitch packet;
+            if (packet.ParseFromArray(data.packet_buffer, data.payload_size)) {
+                onAuthConnectToSwitch(data, packet);
+            }
+            break;
+        }
+        case CONNECTION_ACCEPTED: {
+            mip::PacketConnectionAccepted packet;
+            if (packet.ParseFromArray(data.packet_buffer, data.payload_size)) {
+                onConnectionAccepted(data, packet);
+            }
+            break;
+        }
+        case AGENT_MRP: {
+            mip::PacketAgentMRP packet;
+            if (packet.ParseFromArray(data.packet_buffer, data.payload_size)) {
+                onAgentMRP(data, packet);
+            }
+            break;
+        }
+        default:
+            break;
+    }
+}
+
+// ---------------------------------------------------------------------------
+//  Default (no-op) implementations of all virtual handlers
+// ---------------------------------------------------------------------------
+
+void Dispatch::onClose       (close_data)                                          {}
+void Dispatch::onTunReady    (tun_data)                                            {}
+void Dispatch::onHeartbeat   (socket_data)                                         {}
+
+void Dispatch::onSwitchMIP   (socket_data, mip::PacketSwitchMIP&)                 {}
+void Dispatch::onAgentMIP    (socket_data, mip::PacketAgentMIP&)                   {}
+
+void Dispatch::onConnectToSwitch     (socket_data, mip::PacketConnectToSwitch&)    {}
+void Dispatch::onAuthConnectToSwitch (socket_data, mip::PacketAuthConnectToSwitch&){}
+void Dispatch::onAgentConnectionToken(socket_data, mip::PacketAgentConnectionToken&){}
+void Dispatch::onConnectionAccepted  (socket_data, mip::PacketConnectionAccepted&) {}
+
+void Dispatch::onAgentMRP (socket_data, mip::PacketAgentMRP&)                      {}

--- a/src/switch/CMakeLists.txt
+++ b/src/switch/CMakeLists.txt
@@ -1,0 +1,9 @@
+# CMakeLists.txt for switch
+
+add_executable(switch setup.cpp)
+
+set_target_properties(switch PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+)
+
+target_link_libraries(switch PRIVATE vnet)

--- a/src/switch/setup.cpp
+++ b/src/switch/setup.cpp
@@ -1,0 +1,325 @@
+#include <iostream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include <algorithm>
+#include <chrono>
+#include <thread>
+#include <csignal>
+#include <cstring>
+
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <netinet/tcp.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#include "mip.pb.h"
+#include "common/config.h"
+#include "common/socket_utils.h"
+#include "vnet/protocol/dispatch.hpp"
+#include "vnet/netqueue/netqueue.hpp"
+
+using namespace vnet::protocol;
+using namespace vnet::netqueue;
+using clk = std::chrono::steady_clock;
+
+static const int                  LISTEN_BACKLOG      = 64;
+static const std::chrono::seconds HEARTBEAT_INTERVAL  {30};
+static const std::chrono::seconds TOKEN_EXPIRY        {60};
+static const int                  MAX_CONNECT_RETRIES = 20;
+static const int                  RETRY_DELAY_MS      = 2000;
+
+static volatile sig_atomic_t g_running = 1;
+static void on_signal(int) { g_running = 0; }
+
+// ---------------------------------------------------------------------------
+//  Connection metadata
+// ---------------------------------------------------------------------------
+
+enum class ConnRole { CONDUCTOR, AGENT_PENDING, AGENT_AUTHENTICATED };
+
+struct ConnInfo {
+    ConnRole    role;
+    std::string name;
+    int         fd = -1;
+    clk::time_point last_hb_sent = clk::now();
+};
+
+// ---------------------------------------------------------------------------
+//  Switch state
+// ---------------------------------------------------------------------------
+
+struct SwitchState {
+    /* Pending tokens pushed by the conductor before the agent connects */
+    struct PendingToken {
+        std::string    agent_name;
+        clk::time_point created;
+    };
+    std::unordered_map<uint64_t, PendingToken> pending_tokens;
+
+    /* Authenticated agent connections */
+    std::vector<ConnInfo*> agents;
+
+    /* Conductor connection info */
+    ConnInfo* conductor = nullptr;
+
+    void expire_tokens() {
+        auto now = clk::now();
+        for (auto it = pending_tokens.begin(); it != pending_tokens.end(); ) {
+            if (now - it->second.created > TOKEN_EXPIRY)
+                it = pending_tokens.erase(it);
+            else
+                ++it;
+        }
+    }
+};
+
+static SwitchState g_state;
+
+// ---------------------------------------------------------------------------
+//  Dispatch
+// ---------------------------------------------------------------------------
+
+struct SwitchDispatch : public Dispatch {
+
+    /*
+     * Received from the conductor: a new agent is about to connect.
+     * Store the token so we can validate it later.
+     */
+    void onAgentConnectionToken(socket_data data,
+                                mip::PacketAgentConnectionToken& pkt) override {
+        uint64_t token = pkt.connection_token();
+        std::string agent = pkt.agent_name();
+
+        g_state.pending_tokens[token] = { agent, clk::now() };
+
+        std::cout << "[Switch] Expecting agent " << agent
+                  << " (token=" << token << ")\n";
+    }
+
+    /*
+     * An agent that has connected to us sends its token.
+     * Validate and either accept or drop.
+     */
+    void onAuthConnectToSwitch(socket_data data,
+                               mip::PacketAuthConnectToSwitch& pkt) override {
+        auto* info = static_cast<ConnInfo*>(data.ptr_data);
+        uint64_t token = pkt.connection_token();
+
+        auto it = g_state.pending_tokens.find(token);
+        if (it == g_state.pending_tokens.end()) {
+            std::cerr << "[Switch] Rejected agent: invalid token "
+                      << token << "\n";
+            return;     // NetQueue will see no further reads → eventually close
+        }
+
+        info->role = ConnRole::AGENT_AUTHENTICATED;
+        info->name = it->second.agent_name;
+
+        g_state.pending_tokens.erase(it);
+        g_state.agents.push_back(info);
+
+        // Send acceptance
+        mip::PacketConnectionAccepted ack;
+        send_protobuf_packet(data.fd, PacketType::CONNECTION_ACCEPTED, ack);
+
+        std::cout << "[Switch] Agent " << info->name
+                  << " authenticated (fd=" << data.fd << ")\n";
+    }
+
+    void onHeartbeat(socket_data) override {}
+
+    void onClose(close_data data) override {
+        auto* info = static_cast<ConnInfo*>(data.ptr_data);
+        if (!info) return;
+
+        if (info->role != ConnRole::AGENT_PENDING) {
+            std::cout << "[Switch] Connection closed: " << info->name
+                      << " (fd=" << data.fd << ")\n";
+        }
+
+        if (info->role == ConnRole::AGENT_AUTHENTICATED) {
+            g_state.agents.erase(
+                std::remove(g_state.agents.begin(), g_state.agents.end(), info),
+                g_state.agents.end());
+        }
+        if (info == g_state.conductor) {
+            g_state.conductor = nullptr;
+        }
+
+        delete info;
+    }
+};
+
+// ---------------------------------------------------------------------------
+//  Heartbeat sender
+// ---------------------------------------------------------------------------
+
+static void send_heartbeats() {
+    auto now = clk::now();
+    auto try_hb = [&](ConnInfo* c) {
+        if (c && c->fd >= 0 && now - c->last_hb_sent >= HEARTBEAT_INTERVAL) {
+            send_heartbeat(c->fd);
+            c->last_hb_sent = now;
+        }
+    };
+
+    try_hb(g_state.conductor);
+    for (auto* a : g_state.agents) try_hb(a);
+}
+
+// ---------------------------------------------------------------------------
+//  connect_to with retries (waits for the target to be up)
+// ---------------------------------------------------------------------------
+
+static int connect_with_retry(const MachineConfig& mc, const char* label) {
+    for (int attempt = 1; attempt <= MAX_CONNECT_RETRIES; attempt++) {
+        int fd = connect_to(mc);
+        if (fd >= 0) return fd;
+
+        std::cerr << "[Switch] " << label << " attempt " << attempt
+                  << "/" << MAX_CONNECT_RETRIES << " failed, retrying...\n";
+        std::this_thread::sleep_for(std::chrono::milliseconds(RETRY_DELAY_MS));
+    }
+    return -1;
+}
+
+// ---------------------------------------------------------------------------
+//  Main
+// ---------------------------------------------------------------------------
+
+int main(int argc, char** argv) {
+    GOOGLE_PROTOBUF_VERIFY_VERSION;
+    std::cout << std::unitbuf;
+    std::cerr << std::unitbuf;
+    signal(SIGINT,  on_signal);
+    signal(SIGTERM, on_signal);
+    signal(SIGPIPE, SIG_IGN);
+
+    if (argc != 4) {
+        std::cerr << "Usage: ./switch <name> <auth_key> <port>\n";
+        return 1;
+    }
+
+    std::string switch_name = argv[1];
+    std::string auth_key    = argv[2];
+    uint16_t    port        = static_cast<uint16_t>(std::stoi(argv[3]));
+
+    // --- Read conductor address from environment ---
+    const char* cdt_ip_env   = std::getenv("CONDUCTOR_IP");
+    const char* cdt_port_env = std::getenv("CONDUCTOR_PORT");
+    if (!cdt_ip_env || !cdt_port_env) {
+        std::cerr << "[Switch] CONDUCTOR_IP and CONDUCTOR_PORT must be set\n";
+        return 1;
+    }
+
+    MachineConfig conductor_cfg {
+        cdt_ip_env,
+        static_cast<uint16_t>(std::stoi(cdt_port_env))
+    };
+
+    // --- 1. Connect to conductor (blocking) and send Switch MIP ---
+    std::cout << "[Switch] Connecting to conductor at "
+              << conductor_cfg.ip << ":" << conductor_cfg.port << " ...\n";
+
+    int cdt_sock = connect_with_retry(conductor_cfg, "conductor");
+    if (cdt_sock < 0) {
+        std::cerr << "[Switch] Cannot reach conductor after "
+                  << MAX_CONNECT_RETRIES << " attempts\n";
+        return 1;
+    }
+
+    mip::PacketSwitchMIP mip_pkt;
+    mip_pkt.set_name(switch_name);
+    mip_pkt.set_auth_key(auth_key);
+    mip_pkt.set_network("::internet");   // reachable from any network
+    mip_pkt.set_port(port);
+
+    if (!send_protobuf_packet(cdt_sock, PacketType::SWITCH_MIP, mip_pkt)) {
+        std::cerr << "[Switch] Failed to send MIP\n";
+        close(cdt_sock);
+        return 1;
+    }
+
+    std::cout << "[Switch] Registered with conductor as " << switch_name
+              << " on port " << port << "\n";
+
+    // Switch the conductor fd to non-blocking for the event loop
+    set_nonblocking(cdt_sock);
+
+    int flag = 1;
+    setsockopt(cdt_sock, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag));
+
+    // --- 2. Create listener for agents ---
+    int listener = socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
+    if (listener < 0) { perror("socket"); return 1; }
+
+    int optval = 1;
+    setsockopt(listener, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
+
+    sockaddr_in addr{};
+    addr.sin_family      = AF_INET;
+    addr.sin_port        = htons(port);
+    addr.sin_addr.s_addr = INADDR_ANY;
+
+    if (bind(listener, (sockaddr*)&addr, sizeof(addr)) < 0) {
+        perror("bind"); return 1;
+    }
+    if (listen(listener, LISTEN_BACKLOG) < 0) {
+        perror("listen"); return 1;
+    }
+
+    std::cout << "[Switch] Listening for agents on port " << port << "\n";
+
+    // --- 3. NetQueue setup ---
+    SwitchDispatch dispatch;
+    NetworkQueueHandler handler = makeNetworkQueueHandler(&dispatch);
+    NetQueue queue(handler, /*epoll_timeout_ms=*/200);
+
+    // Add conductor connection to the queue
+    auto* cdt_info = new ConnInfo();
+    cdt_info->role = ConnRole::CONDUCTOR;
+    cdt_info->name = "conductor";
+    cdt_info->fd   = cdt_sock;
+    g_state.conductor = cdt_info;
+
+    if (!queue.put_sck(cdt_sock, cdt_info)) {
+        std::cerr << "[Switch] Failed to add conductor fd to queue\n";
+        return 1;
+    }
+
+    // --- 4. Event loop ---
+    while (g_running) {
+        // Accept agents (non-blocking)
+        while (true) {
+            int agent_fd = accept4(listener, nullptr, nullptr, SOCK_NONBLOCK);
+            if (agent_fd < 0) break;
+
+            setsockopt(agent_fd, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag));
+
+            auto* info = new ConnInfo();
+            info->role = ConnRole::AGENT_PENDING;
+            info->fd   = agent_fd;
+
+            if (!queue.put_sck(agent_fd, info)) {
+                close(agent_fd);
+                delete info;
+            }
+        }
+
+        // Process events
+        queue.wait_and_process();
+
+        // Expire old tokens
+        g_state.expire_tokens();
+
+        // Heartbeats
+        send_heartbeats();
+    }
+
+    close(listener);
+    std::cout << "[Switch] Shutting down.\n";
+    google::protobuf::ShutdownProtobufLibrary();
+    return 0;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-
+# CMakeLists.txt for tests directory
 include(CTest)
 set(CTEST_TIMEOUT 30)
 

--- a/tests/netqueue/netqueue_test_handler.hpp
+++ b/tests/netqueue/netqueue_test_handler.hpp
@@ -8,13 +8,13 @@ std::vector<socket_data> socket_datas;
 std::vector<close_data>  close_datas;
 std::vector<tun_data>    tun_datas;
 
-void onSocketReady (socket_data data) {
+void onSocketReady (void* ptr_data, socket_data data) {
     socket_datas.push_back(data);
 }
-void onTunReady (tun_data data) {
+void onTunReady (void* ptr_data, tun_data data) {
     tun_datas.push_back(data);
 }
-void onClose (close_data data) {
+void onClose (void* ptr_data, close_data data) {
     close_datas.push_back(data);
 }
 
@@ -23,6 +23,7 @@ NetworkQueueHandler createTestHandler () {
     handler.onSocketReady = &onSocketReady;
     handler.onTunReady    = &onTunReady;
     handler.onClose       = &onClose;
+    handler.ptr_data      = nullptr; // unused in this test
 
     return handler;
 }


### PR DESCRIPTION
## Implement Machine Initialization Protocol (MIP)

### Summary

Implements the Machine Initialization Protocol as specified in PLY-BCK 010 (Virtual Network), enabling agents to join the virtual network through a three-party handshake between the conductor, switches, and agents.

### What this does

**Conductor** — Listens on port 5000 and accepts both switch registrations and agent MIP requests. When a switch connects, it registers itself with its name, network, and listening port. When an agent connects, the conductor selects a reachable switch using round-robin load balancing with a network reachability check (same network or `::internet`), generates a connection token, and simultaneously notifies both the agent and the switch to complete the handshake.

**Switch** — Connects to the conductor at startup and sends a `PacketSwitchMIP` to register. It then listens for incoming agent connections. When the conductor pushes a `PacketAgentConnectionToken`, the switch stores it in a pending token map. When an agent connects and presents a valid token via `PacketAuthConnectToSwitch`, the switch validates it and responds with `PacketConnectionAccepted`. Tokens expire after 60 seconds.

**Agent** — Connects to the conductor, sends `PacketAgentMIP`, and receives a switch assignment containing the switch name, IPv4, port, and connection token. It then opens a second TCP connection to the assigned switch, authenticates with the token, and waits for acceptance before entering the event loop.

All three components maintain persistent connections after the MIP completes and use periodic heartbeats (30s interval) to keep them alive.

### Protocol layer

- Packet framing uses a 6-byte header: 4-byte payload size + 2-byte packet type, both in network byte order, matching the `PacketHeader` struct used by `NetQueue`
- Added `HEARTBEAT` (type 0) and `AGENT_MRP` packet types for keepalive and reconnection
- Hostname resolution via `getaddrinfo` for Docker service discovery compatibility
- All connections are non-blocking after the initial handshake, managed through the epoll-based `NetQueue`

### Reconnection

Agents support reconnection via `PacketAgentMRP`, allowing them to re-register their control-plane socket with the conductor without repeating the full MIP.

### Build system

- Consolidated shared sources (protocol, netqueue, socket_utils) into a single `vnet` static library
- Executables link against `vnet` instead of compiling sources individually
- Tests are behind `-DBUILD_TESTS=ON` so production Docker builds skip GoogleTest fetching
- Multi-stage Dockerfiles for smaller runtime images
- Switches and agents use healthcheck-gated `depends_on` to ensure proper startup ordering

### Docker

Multi-stage Dockerfiles keep runtime images small by separating the build environment from the final binary. The compose file uses healthcheck-gated `depends_on` to enforce startup ordering: the conductor must be healthy before switches start, and all switches must be healthy before any agent starts. Each service resolves the conductor address via Docker DNS (`vnet-conductor`), and environment variables (`CONDUCTOR_IP`, `CONDUCTOR_PORT`) configure the connection target. All services run on a shared bridge network and restart automatically on failure.