### PR TITLE
Fix MIP handshake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 .vscode
 .DS_Store
 .idea
+compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,13 @@ SET(VNET_SOURCE_FILES
 
         src/netqueue/element.cpp
         src/netqueue/netqueue.cpp
-        src/netqueue/handler.cpp)
+        src/netqueue/handler.cpp
+
+        src/blackbox/ipv4.cpp
+        src/blackbox/agent_registry.cpp
+        src/blackbox/routing_table.cpp
+        src/blackbox/config.cpp
+        src/blackbox/blackbox.cpp)
 
 add_library(vnet STATIC ${VNET_SOURCE_FILES})
 target_link_libraries(vnet PUBLIC vnet_proto)

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -27,6 +27,6 @@ COPY . /vnet
 
 RUN mkdir -p build
 WORKDIR /vnet/build
-RUN cmake -B . -S .. -GNinja -DENABLE_COVERAGE=ON -DBUILD_TESTS=ON && ninja
+RUN cmake -B . -S .. -GNinja -DENABLE_COVERAGE=ON && ninja
 
 ENTRYPOINT ["ctest", "--output-on-failure", "-j4"]

--- a/include/vnet/blackbox/agent_registry.hpp
+++ b/include/vnet/blackbox/agent_registry.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+
+namespace vnet::blackbox {
+
+    /**
+     * Represents a single agent connected to this switch.
+     */
+    struct AgentEntry {
+        std::string name;
+        uint32_t    virtual_ipv4;   // network order
+        int         fd;
+    };
+
+    /**
+     * Maintains the set of agents currently connected to this switch,
+     * indexed three ways for O(1) lookup in the packet processing path.
+     *
+     * Thread safety: NOT thread-safe. Intended to be used from a
+     * single-threaded event loop (epoll).
+     *
+     * Ownership: the registry owns the AgentEntry objects. They are
+     * freed when unregistered or when the registry is destroyed.
+     */
+    class AgentRegistry {
+    public:
+        /**
+         * Register a new agent. If an agent with the same name was
+         * already registered, the old entry is removed first.
+         *
+         * @param name            The agent name (from MIP).
+         * @param virtual_ipv4    The agent's virtual IP (network order, from config).
+         * @param fd              The TCP fd for communicating with the agent.
+         * @return pointer to the created entry, or nullptr on failure.
+         */
+        AgentEntry* register_agent(const std::string& name,
+                                   uint32_t virtual_ipv4,
+                                   int fd);
+
+        /**
+         * Remove an agent by fd. Called when the agent disconnects.
+         * Frees the AgentEntry.
+         */
+        void unregister_by_fd(int fd);
+
+        /**
+         * Remove an agent by name. Frees the AgentEntry.
+         */
+        void unregister_by_name(const std::string& name);
+
+        /** Look up an agent by its virtual IPv4. O(1). */
+        AgentEntry* find_by_ipv4(uint32_t ipv4) const;
+
+        /** Look up an agent by its TCP fd. O(1). */
+        AgentEntry* find_by_fd(int fd) const;
+
+        /** Look up an agent by name. O(1). */
+        AgentEntry* find_by_name(const std::string& name) const;
+
+        /** Number of registered agents. */
+        size_t size() const;
+
+        ~AgentRegistry();
+
+    private:
+        void remove_entry(AgentEntry* entry);
+
+        std::unordered_map<uint32_t, AgentEntry*>     by_ipv4_;
+        std::unordered_map<int, AgentEntry*>           by_fd_;
+        std::unordered_map<std::string, AgentEntry*>   by_name_;
+    };
+
+};

--- a/include/vnet/blackbox/blackbox.hpp
+++ b/include/vnet/blackbox/blackbox.hpp
@@ -1,0 +1,167 @@
+#pragma once
+
+#include <cstdint>
+#include <cstddef>
+#include <string>
+
+#include "vnet/blackbox/config.hpp"
+#include "vnet/blackbox/agent_registry.hpp"
+#include "vnet/blackbox/routing_table.hpp"
+#include "vnet/blackbox/ipv4.hpp"
+
+namespace vnet::blackbox {
+
+    // -----------------------------------------------------------------
+    //  Types for the source of an incoming packet
+    // -----------------------------------------------------------------
+
+    /**
+     * Tells the black box what kind of fd delivered the packet.
+     * The switch already knows this from ConnInfo::role.
+     */
+    enum class SourceType {
+        AGENT,      // From a local agent (needs source validation)
+        SWITCH,     // From a peer switch (source already validated by origin switch)
+        TUN         // From the internet TUN device (return traffic)
+    };
+
+    // -----------------------------------------------------------------
+    //  Types for the packet decision
+    // -----------------------------------------------------------------
+
+    enum class PacketAction {
+        DELIVER_LOCAL,      // Write the raw IPv4 payload to target_fd (local agent)
+        FORWARD_SWITCH,     // Wrap in PacketIPv4Raw and send to target_fd (peer switch)
+        FORWARD_INTERNET,   // Write the raw IPv4 payload to the TUN fd
+        REQUEST_ROUTE,      // No route known; caller should send PacketPrepareRouteForTarget
+        DROP                // Drop the packet
+    };
+
+    enum class DropReason {
+        NONE,
+        MALFORMED_PACKET,       // IPv4 header parse failed
+        SOURCE_SPOOF,           // Source IP doesn't match the agent's registered IP
+        SOURCE_UNKNOWN,         // Source fd not found in agent registry
+        DEST_UNREACHABLE,       // No local agent, no route, no internet
+        ACL_DENIED              // ACL check failed (agent-to-agent or internet)
+    };
+
+    struct PacketDecision {
+        PacketAction action       = PacketAction::DROP;
+        int          target_fd    = -1;         // for DELIVER_LOCAL, FORWARD_SWITCH
+        uint32_t     dest_ipv4    = 0;          // for REQUEST_ROUTE
+        DropReason   drop_reason  = DropReason::NONE;
+    };
+
+    // -----------------------------------------------------------------
+    //  BlackBox
+    // -----------------------------------------------------------------
+
+    /**
+     * The switch's packet processing engine.
+     *
+     * Responsibilities:
+     *   - Source validation (anti-spoofing for agent-sourced packets)
+     *   - Destination lookup (local agent, remote agent via routing, or internet)
+     *   - Packet decision (deliver, forward, request route, or drop)
+     *
+     * Does NOT perform I/O. The switch event loop calls process() and
+     * acts on the returned PacketDecision.
+     *
+     * Thread safety: NOT thread-safe. Intended for single-threaded
+     * event loop usage.
+     *
+     * Lifecycle hooks:
+     *   - on_agent_authenticated() : called after MIP, populates agent registry
+     *   - on_agent_disconnected()  : called on fd close, cleans up
+     *   - on_route_update()        : called on PacketNextForTarget from conductor
+     *   - on_switch_disconnected() : called when a peer switch drops
+     */
+    class BlackBox {
+    public:
+        /**
+         * Construct a black box with the given config.
+         *
+         * @param config  Parsed config (agent→IP mappings, internet permissions).
+         *                The BlackBox takes a copy.
+         * @param tun_fd  File descriptor of the internet TUN device,
+         *                or -1 if internet is not available.
+         */
+        BlackBox(const Config& config, int tun_fd);
+
+        // ----- Packet processing -----
+
+        /**
+         * Process a raw IPv4 packet and decide what to do with it.
+         *
+         * @param source_type  What kind of fd delivered the packet.
+         * @param source_fd    The fd that delivered the packet.
+         * @param raw_ipv4     Pointer to the raw IPv4 packet bytes.
+         * @param len          Number of bytes in raw_ipv4.
+         * @return A PacketDecision telling the caller what to do.
+         */
+        PacketDecision process(SourceType source_type, int source_fd,
+                               const uint8_t* raw_ipv4, size_t len);
+
+        // ----- Lifecycle hooks (called by the switch) -----
+
+        /**
+         * An agent has completed MIP and been authenticated.
+         * Looks up the config for the agent's virtual IP and
+         * registers it in the agent registry.
+         *
+         * @param name  Agent name (from MIP).
+         * @param fd    The agent's TCP fd.
+         * @return true if the agent was found in the config and registered.
+         */
+        bool on_agent_authenticated(const std::string& name, int fd);
+
+        /**
+         * An agent's fd was closed (disconnect, error, etc.).
+         * Removes the agent from the registry.
+         */
+        void on_agent_disconnected(int fd);
+
+        /**
+         * Received PacketNextForTarget from the conductor.
+         * Updates the routing table.
+         *
+         * @param dest_ipv4       Target IP (network order).
+         * @param next_switch_fd  The peer switch fd to forward to,
+         *                        or -1 to remove the route (target disconnected).
+         */
+        void on_route_update(uint32_t dest_ipv4, int next_switch_fd);
+
+        /**
+         * A peer switch fd was closed.
+         * Removes all routes pointing to that switch.
+         */
+        void on_switch_disconnected(int switch_fd);
+
+        // ----- Accessors (for logging, debugging) -----
+
+        const AgentRegistry& agents() const;
+        const RoutingTable&  routes() const;
+        const Config&        config() const;
+
+    private:
+        PacketDecision process_from_agent(int source_fd,
+                                          const IPv4Header& hdr,
+                                          const uint8_t* raw, size_t len);
+
+        PacketDecision process_from_switch(const IPv4Header& hdr,
+                                           const uint8_t* raw, size_t len);
+
+        PacketDecision process_from_tun(const IPv4Header& hdr,
+                                        const uint8_t* raw, size_t len);
+
+        PacketDecision route_to_destination(uint32_t src_ipv4,
+                                            uint32_t dest_ipv4);
+
+        Config         config_;
+        AgentRegistry  registry_;
+        RoutingTable   routing_;
+        int            tun_fd_;
+    };
+
+};

--- a/include/vnet/blackbox/config.hpp
+++ b/include/vnet/blackbox/config.hpp
@@ -1,0 +1,108 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace vnet::blackbox {
+
+    /**
+     * Parsed configuration for the black box.
+     *
+     * The config file has one entry per line.
+     * Blank lines and lines starting with '#' are ignored.
+     *
+     * Two kinds of entries:
+     *
+     *   IP ASSIGNMENT:
+     *     agent_name  ip_address
+     *
+     *     Maps a virtual IPv4 address to an agent name.
+     *     Distinguished from ACL rules because the second
+     *     token is a valid IPv4 address.
+     *
+     *   ACL RULE:
+     *     agent_name  agent_name
+     *       Allows bidirectional communication between two agents.
+     *
+     *     agent_name  ::internet:ip_address
+     *       Allows this agent to reach a specific internet IP.
+     *       Return traffic from that IP is also allowed.
+     *
+     * Example:
+     *   # IP assignments
+     *   contestant1  10.0.1.1
+     *   contestant2  10.0.1.2
+     *   gameserver   10.0.0.1
+     *
+     *   # Contestants can talk to game server only
+     *   contestant1  gameserver
+     *   contestant2  gameserver
+     *
+     *   # Game server can reach specific internet hosts
+     *   gameserver   ::internet:8.8.8.8
+     *   gameserver   ::internet:1.1.1.1
+     */
+    class Config {
+    public:
+        /**
+         * Load and parse a config file.
+         *
+         * IP assignments must appear before ACL rules that reference
+         * agent names (so that agent names can be validated).
+         *
+         * @param path  Path to the config file.
+         * @return true on success, false on parse error or I/O failure.
+         */
+        bool load(const std::string& path);
+
+        // ----- IP assignment lookups -----
+
+        /** Find the agent name that owns a given IPv4. Empty if not found. */
+        std::string find_agent_for_ip(uint32_t ipv4) const;
+
+        /** Find the virtual IPv4 assigned to an agent. 0 if not found. */
+        uint32_t find_ip_for_agent(const std::string& name) const;
+
+        /** All configured agent names and their IPs. */
+        const std::unordered_map<std::string, uint32_t>& agents() const;
+
+        // ----- ACL lookups -----
+
+        /**
+         * Can the agent at src_ipv4 communicate with the agent at dst_ipv4?
+         * Bidirectional: if A→B is allowed, B→A is also allowed.
+         */
+        bool can_agents_communicate(uint32_t src_ipv4, uint32_t dst_ipv4) const;
+
+        /**
+         * Can the agent at agent_ipv4 reach the given internet IP?
+         * Also used for return traffic: if agent can reach internet_ipv4,
+         * then return traffic from internet_ipv4 to agent is allowed.
+         */
+        bool can_reach_internet_ip(uint32_t agent_ipv4, uint32_t internet_ipv4) const;
+
+        /**
+         * Does this agent have any internet rules at all?
+         */
+        bool has_any_internet_access(uint32_t agent_ipv4) const;
+
+    private:
+        // IP assignments
+        std::unordered_map<std::string, uint32_t> name_to_ip_;
+        std::unordered_map<uint32_t, std::string> ip_to_name_;
+
+        // ACL: agent-to-agent (bidirectional)
+        // agent_ipv4 → set of agent_ipv4s it can talk to
+        std::unordered_map<uint32_t, std::unordered_set<uint32_t>> agent_acl_;
+
+        // ACL: agent-to-internet
+        // agent_ipv4 → set of internet IPs it can reach
+        std::unordered_map<uint32_t, std::unordered_set<uint32_t>> internet_acl_;
+
+        static bool is_ipv4(const std::string& s);
+    };
+
+};

--- a/include/vnet/blackbox/ipv4.hpp
+++ b/include/vnet/blackbox/ipv4.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <cstdint>
+#include <cstddef>
+
+namespace vnet::blackbox {
+
+    /**
+     * Parsed fields from an IPv4 packet header.
+     *
+     * All multi-byte fields are stored in network byte order
+     * (big endian) so they can be compared directly against
+     * addresses stored elsewhere in the system without conversion.
+     *
+     * Ports are only meaningful for TCP (protocol 6) and
+     * UDP (protocol 17). For other protocols (e.g. ICMP)
+     * they are set to 0.
+     */
+    struct IPv4Header {
+        uint8_t  version;
+        uint8_t  ihl;              // header length in 32-bit words (>= 5)
+        uint16_t total_length;     // network order
+        uint8_t  protocol;         // 1=ICMP, 6=TCP, 17=UDP
+        uint32_t src_ip;           // network order
+        uint32_t dst_ip;           // network order
+        uint16_t src_port;         // network order (0 if not TCP/UDP)
+        uint16_t dst_port;         // network order (0 if not TCP/UDP)
+    };
+
+    static constexpr uint8_t PROTO_ICMP = 1;
+    static constexpr uint8_t PROTO_TCP  = 6;
+    static constexpr uint8_t PROTO_UDP  = 17;
+
+    /**
+     * Parse a raw IPv4 packet and populate `out`.
+     *
+     * Validates:
+     *  - Minimum buffer size (20 bytes)
+     *  - IP version == 4
+     *  - IHL >= 5
+     *  - Total length consistent with buffer size
+     *  - Enough bytes for transport header ports (if TCP/UDP)
+     *
+     * @param data  Pointer to the raw IPv4 packet.
+     * @param len   Number of bytes available in `data`.
+     * @param out   Receives the parsed header fields.
+     * @return true if the packet is well-formed, false otherwise.
+     */
+    bool ipv4_parse(const uint8_t* data, size_t len, IPv4Header& out);
+
+};

--- a/include/vnet/blackbox/routing_table.hpp
+++ b/include/vnet/blackbox/routing_table.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <cstdint>
+#include <unordered_map>
+
+namespace vnet::blackbox {
+
+    /**
+     * Maintains the next-hop switch for each destination IPv4 address
+     * that is not owned by a local agent.
+     *
+     * Populated by PacketNextForTarget messages from the conductor.
+     *
+     * When switch_ipv4 is 0 in PacketNextForTarget, the target has
+     * disconnected and the route should be removed.
+     *
+     * Thread safety: NOT thread-safe. Single-threaded event loop.
+     */
+    class RoutingTable {
+    public:
+        /**
+         * Set or update the next-hop for a destination IPv4.
+         *
+         * @param dest_ipv4       Target IP in network order.
+         * @param next_switch_fd  The fd of the TCP connection to the
+         *                        next switch to forward packets to.
+         */
+        void set_route(uint32_t dest_ipv4, int next_switch_fd);
+
+        /**
+         * Remove a route. Called when the conductor sends a
+         * PacketNextForTarget with switch_ipv4 = 0 (target disconnected),
+         * or when a switch-to-switch connection drops.
+         */
+        void remove_route(uint32_t dest_ipv4);
+
+        /**
+         * Remove all routes that point to a specific switch fd.
+         * Called when a switch-to-switch connection drops.
+         */
+        void remove_routes_for_switch(int switch_fd);
+
+        /**
+         * Look up the next-hop fd for a destination IPv4.
+         *
+         * @return The switch fd, or -1 if no route exists.
+         */
+        int lookup(uint32_t dest_ipv4) const;
+
+        /** Number of entries in the table. */
+        size_t size() const;
+
+        void clear();
+
+    private:
+        std::unordered_map<uint32_t, int> routes_;
+    };
+
+};

--- a/include/vnet/protocol/header.hpp
+++ b/include/vnet/protocol/header.hpp
@@ -13,8 +13,8 @@ namespace vnet::protocol {
         uint32_t      payload_size;
         uint_packet_t packet_type;
     public:
-        uint32_t   get_payload_size();
-        PacketType get_packet_type ();
+        uint32_t   get_payload_size() const;
+        PacketType get_packet_type () const;
 
         PacketHeader ();
         PacketHeader (uint32_t payload_size, PacketType packet_type);

--- a/src/blackbox/agent_registry.cpp
+++ b/src/blackbox/agent_registry.cpp
@@ -1,0 +1,81 @@
+#include "vnet/blackbox/agent_registry.hpp"
+
+namespace vnet::blackbox {
+
+    AgentEntry* AgentRegistry::register_agent(const std::string& name,
+                                              uint32_t virtual_ipv4,
+                                              int fd) {
+        // If this name is already registered, clean up the old entry
+        // (handles agent reconnection to the same switch).
+        auto it = by_name_.find(name);
+        if (it != by_name_.end()) {
+            remove_entry(it->second);
+        }
+
+        auto* entry = new (std::nothrow) AgentEntry();
+        if (!entry) return nullptr;
+
+        entry->name         = name;
+        entry->virtual_ipv4 = virtual_ipv4;
+        entry->fd           = fd;
+
+        by_ipv4_[virtual_ipv4] = entry;
+        by_fd_[fd]             = entry;
+        by_name_[name]         = entry;
+
+        return entry;
+    }
+
+    void AgentRegistry::unregister_by_fd(int fd) {
+        auto it = by_fd_.find(fd);
+        if (it == by_fd_.end()) return;
+        remove_entry(it->second);
+    }
+
+    void AgentRegistry::unregister_by_name(const std::string& name) {
+        auto it = by_name_.find(name);
+        if (it == by_name_.end()) return;
+        remove_entry(it->second);
+    }
+
+    AgentEntry* AgentRegistry::find_by_ipv4(uint32_t ipv4) const {
+        auto it = by_ipv4_.find(ipv4);
+        return (it != by_ipv4_.end()) ? it->second : nullptr;
+    }
+
+    AgentEntry* AgentRegistry::find_by_fd(int fd) const {
+        auto it = by_fd_.find(fd);
+        return (it != by_fd_.end()) ? it->second : nullptr;
+    }
+
+    AgentEntry* AgentRegistry::find_by_name(const std::string& name) const {
+        auto it = by_name_.find(name);
+        return (it != by_name_.end()) ? it->second : nullptr;
+    }
+
+    size_t AgentRegistry::size() const {
+        return by_name_.size();
+    }
+
+    void AgentRegistry::remove_entry(AgentEntry* entry) {
+        if (!entry) return;
+
+        by_ipv4_.erase(entry->virtual_ipv4);
+        by_fd_.erase(entry->fd);
+        by_name_.erase(entry->name);
+
+        delete entry;
+    }
+
+    AgentRegistry::~AgentRegistry() {
+        // Delete all remaining entries.
+        // Iterate by_name_ since each entry appears exactly once there.
+        for (auto& [name, entry] : by_name_) {
+            delete entry;
+        }
+        by_ipv4_.clear();
+        by_fd_.clear();
+        by_name_.clear();
+    }
+
+};

--- a/src/blackbox/blackbox.cpp
+++ b/src/blackbox/blackbox.cpp
@@ -1,0 +1,206 @@
+#include "vnet/blackbox/blackbox.hpp"
+
+#include <iostream>
+
+namespace vnet::blackbox {
+
+    BlackBox::BlackBox(const Config& config, int tun_fd)
+        : config_(config), tun_fd_(tun_fd) {}
+
+    // =================================================================
+    //  Lifecycle hooks
+    // =================================================================
+
+    bool BlackBox::on_agent_authenticated(const std::string& name, int fd) {
+        uint32_t ipv4 = config_.find_ip_for_agent(name);
+        if (ipv4 == 0) {
+            std::cerr << "[BlackBox] Agent '" << name
+                      << "' not found in config, rejecting\n";
+            return false;
+        }
+
+        AgentEntry* entry = registry_.register_agent(name, ipv4, fd);
+        if (!entry) {
+            std::cerr << "[BlackBox] Failed to register agent '" << name << "'\n";
+            return false;
+        }
+
+        std::cout << "[BlackBox] Agent registered: " << name
+                  << " (fd=" << fd << ")\n";
+
+        return true;
+    }
+
+    void BlackBox::on_agent_disconnected(int fd) {
+        AgentEntry* entry = registry_.find_by_fd(fd);
+        if (entry) {
+            std::cout << "[BlackBox] Agent disconnected: " << entry->name
+                      << " (fd=" << fd << ")\n";
+        }
+        registry_.unregister_by_fd(fd);
+    }
+
+    void BlackBox::on_route_update(uint32_t dest_ipv4, int next_switch_fd) {
+        if (next_switch_fd < 0) {
+            routing_.remove_route(dest_ipv4);
+        } else {
+            routing_.set_route(dest_ipv4, next_switch_fd);
+        }
+    }
+
+    void BlackBox::on_switch_disconnected(int switch_fd) {
+        routing_.remove_routes_for_switch(switch_fd);
+    }
+
+    // =================================================================
+    //  Accessors
+    // =================================================================
+
+    const AgentRegistry& BlackBox::agents() const { return registry_; }
+    const RoutingTable&  BlackBox::routes() const  { return routing_; }
+    const Config&        BlackBox::config() const  { return config_; }
+
+    // =================================================================
+    //  Packet processing — entry point
+    // =================================================================
+
+    PacketDecision BlackBox::process(SourceType source_type, int source_fd,
+                                     const uint8_t* raw_ipv4, size_t len) {
+        IPv4Header hdr{};
+        if (!ipv4_parse(raw_ipv4, len, hdr)) {
+            return { PacketAction::DROP, -1, 0, DropReason::MALFORMED_PACKET };
+        }
+
+        switch (source_type) {
+            case SourceType::AGENT:
+                return process_from_agent(source_fd, hdr, raw_ipv4, len);
+            case SourceType::SWITCH:
+                return process_from_switch(hdr, raw_ipv4, len);
+            case SourceType::TUN:
+                return process_from_tun(hdr, raw_ipv4, len);
+        }
+
+        return { PacketAction::DROP, -1, 0, DropReason::MALFORMED_PACKET };
+    }
+
+    // =================================================================
+    //  Packet from a local agent
+    //
+    //  1. Validate source IP (anti-spoofing)
+    //  2. Check ACL + route to destination
+    // =================================================================
+
+    PacketDecision BlackBox::process_from_agent(int source_fd,
+                                                const IPv4Header& hdr,
+                                                const uint8_t* raw,
+                                                size_t len) {
+        // Step 1: Find the agent that owns this fd
+        AgentEntry* sender = registry_.find_by_fd(source_fd);
+        if (!sender) {
+            return { PacketAction::DROP, -1, 0, DropReason::SOURCE_UNKNOWN };
+        }
+
+        // Step 2: Anti-spoofing — the source IP in the packet MUST
+        //         match the virtual IP assigned to this agent.
+        if (hdr.src_ip != sender->virtual_ipv4) {
+            return { PacketAction::DROP, -1, 0, DropReason::SOURCE_SPOOF };
+        }
+
+        // Step 3: ACL + route to destination
+        return route_to_destination(sender->virtual_ipv4, hdr.dst_ip);
+    }
+
+    // =================================================================
+    //  Packet from a peer switch
+    //
+    //  The source switch already checked outgoing ACLs.
+    //  Since ACL rules are bidirectional, if the source switch
+    //  allowed it, the incoming side is also authorized.
+    //  We just deliver to the local agent.
+    // =================================================================
+
+    PacketDecision BlackBox::process_from_switch(const IPv4Header& hdr,
+                                                  const uint8_t* raw,
+                                                  size_t len) {
+        AgentEntry* dest = registry_.find_by_ipv4(hdr.dst_ip);
+        if (dest) {
+            return { PacketAction::DELIVER_LOCAL, dest->fd, 0, DropReason::NONE };
+        }
+
+        return { PacketAction::DROP, -1, 0, DropReason::DEST_UNREACHABLE };
+    }
+
+    // =================================================================
+    //  Packet from the internet TUN (return traffic)
+    //
+    //  The original outgoing packet was ACL-checked.
+    //  For return traffic, verify that the destination agent is
+    //  allowed to reach the source internet IP (bidirectional rule).
+    // =================================================================
+
+    PacketDecision BlackBox::process_from_tun(const IPv4Header& hdr,
+                                               const uint8_t* raw,
+                                               size_t len) {
+        AgentEntry* dest = registry_.find_by_ipv4(hdr.dst_ip);
+        if (!dest) {
+            return { PacketAction::DROP, -1, 0, DropReason::DEST_UNREACHABLE };
+        }
+
+        // Verify that this agent has an ACL rule allowing traffic
+        // to/from this internet IP.
+        if (!config_.can_reach_internet_ip(hdr.dst_ip, hdr.src_ip)) {
+            return { PacketAction::DROP, -1, 0, DropReason::ACL_DENIED };
+        }
+
+        return { PacketAction::DELIVER_LOCAL, dest->fd, 0, DropReason::NONE };
+    }
+
+    // =================================================================
+    //  Destination routing with ACL enforcement
+    //
+    //  Priority:
+    //    1. Known agent (local or remote) → check ACL → deliver/forward
+    //    2. Unknown IP → internet → check internet ACL → forward to TUN
+    //    3. Drop
+    // =================================================================
+
+    PacketDecision BlackBox::route_to_destination(uint32_t src_ipv4,
+                                                   uint32_t dest_ipv4) {
+        // 1. Is the destination a known agent?
+        std::string dest_agent = config_.find_agent_for_ip(dest_ipv4);
+        if (!dest_agent.empty()) {
+            // ACL check: can source talk to destination?
+            if (!config_.can_agents_communicate(src_ipv4, dest_ipv4)) {
+                return { PacketAction::DROP, -1, 0, DropReason::ACL_DENIED };
+            }
+
+            // Local agent?
+            AgentEntry* local = registry_.find_by_ipv4(dest_ipv4);
+            if (local) {
+                return { PacketAction::DELIVER_LOCAL, local->fd, 0, DropReason::NONE };
+            }
+
+            // Remote agent — check routing table
+            int next_switch = routing_.lookup(dest_ipv4);
+            if (next_switch >= 0) {
+                return { PacketAction::FORWARD_SWITCH, next_switch, 0, DropReason::NONE };
+            }
+
+            // No route yet — ask the conductor
+            return { PacketAction::REQUEST_ROUTE, -1, dest_ipv4, DropReason::NONE };
+        }
+
+        // 2. Unknown IP — this is internet traffic
+        if (tun_fd_ < 0) {
+            return { PacketAction::DROP, -1, 0, DropReason::DEST_UNREACHABLE };
+        }
+
+        // ACL check: can this agent reach this specific internet IP?
+        if (!config_.can_reach_internet_ip(src_ipv4, dest_ipv4)) {
+            return { PacketAction::DROP, -1, 0, DropReason::ACL_DENIED };
+        }
+
+        return { PacketAction::FORWARD_INTERNET, tun_fd_, 0, DropReason::NONE };
+    }
+
+};

--- a/src/blackbox/config.cpp
+++ b/src/blackbox/config.cpp
@@ -1,0 +1,181 @@
+#include "vnet/blackbox/config.hpp"
+
+#include <fstream>
+#include <sstream>
+#include <iostream>
+#include <arpa/inet.h>
+
+namespace vnet::blackbox {
+
+    static uint32_t parse_ipv4(const std::string& s) {
+        uint32_t addr = 0;
+        if (inet_pton(AF_INET, s.c_str(), &addr) != 1)
+            return 0;
+        return addr;    // network order
+    }
+
+    bool Config::is_ipv4(const std::string& s) {
+        uint32_t dummy = 0;
+        return inet_pton(AF_INET, s.c_str(), &dummy) == 1;
+    }
+
+    static const std::string INTERNET_PREFIX = "::internet:";
+
+    bool Config::load(const std::string& path) {
+        std::ifstream file(path);
+        if (!file.is_open()) {
+            std::cerr << "[Config] Cannot open " << path << "\n";
+            return false;
+        }
+
+        name_to_ip_.clear();
+        ip_to_name_.clear();
+        agent_acl_.clear();
+        internet_acl_.clear();
+
+        // We do two passes:
+        //  Pass 1: collect all lines
+        //  Pass 2: process IP assignments first, then ACL rules
+        // This way agent names in ACL rules can be validated.
+
+        struct Line {
+            int         num;
+            std::string first;
+            std::string second;
+        };
+
+        std::vector<Line> lines;
+        std::string raw;
+        int line_num = 0;
+
+        while (std::getline(file, raw)) {
+            line_num++;
+
+            size_t start = raw.find_first_not_of(" \t");
+            if (start == std::string::npos) continue;
+            if (raw[start] == '#') continue;
+
+            std::istringstream iss(raw.substr(start));
+            std::string first, second;
+            iss >> first >> second;
+
+            if (first.empty() || second.empty()) {
+                std::cerr << "[Config] Line " << line_num
+                          << ": expected two tokens, got '" << raw << "'\n";
+                return false;
+            }
+
+            lines.push_back({line_num, first, second});
+        }
+
+        // --- Pass 1: IP assignments (second token is a valid IPv4) ---
+        for (auto& l : lines) {
+            if (!is_ipv4(l.second))
+                continue;
+
+            uint32_t ipv4 = parse_ipv4(l.second);
+            if (ipv4 == 0) {
+                std::cerr << "[Config] Line " << l.num
+                          << ": invalid IPv4 '" << l.second << "'\n";
+                return false;
+            }
+
+            if (ip_to_name_.count(ipv4)) {
+                std::cerr << "[Config] Line " << l.num
+                          << ": duplicate IP " << l.second << "\n";
+                return false;
+            }
+            if (name_to_ip_.count(l.first)) {
+                std::cerr << "[Config] Line " << l.num
+                          << ": duplicate agent name '" << l.first << "'\n";
+                return false;
+            }
+
+            name_to_ip_[l.first] = ipv4;
+            ip_to_name_[ipv4]    = l.first;
+        }
+
+        // --- Pass 2: ACL rules (second token is agent name or ::internet:ip) ---
+        for (auto& l : lines) {
+            if (is_ipv4(l.second))
+                continue;   // already processed
+
+            // Validate the source agent exists
+            auto src_it = name_to_ip_.find(l.first);
+            if (src_it == name_to_ip_.end()) {
+                std::cerr << "[Config] Line " << l.num
+                          << ": unknown agent '" << l.first << "'\n";
+                return false;
+            }
+            uint32_t src_ip = src_it->second;
+
+            if (l.second.rfind(INTERNET_PREFIX, 0) == 0) {
+                // ::internet:ip_address
+                std::string ip_str = l.second.substr(INTERNET_PREFIX.size());
+                uint32_t inet_ip = parse_ipv4(ip_str);
+                if (inet_ip == 0) {
+                    std::cerr << "[Config] Line " << l.num
+                              << ": invalid internet IP in '" << l.second << "'\n";
+                    return false;
+                }
+
+                internet_acl_[src_ip].insert(inet_ip);
+            } else {
+                // agent-to-agent rule
+                auto dst_it = name_to_ip_.find(l.second);
+                if (dst_it == name_to_ip_.end()) {
+                    std::cerr << "[Config] Line " << l.num
+                              << ": unknown agent '" << l.second << "'\n";
+                    return false;
+                }
+                uint32_t dst_ip = dst_it->second;
+
+                // Bidirectional
+                agent_acl_[src_ip].insert(dst_ip);
+                agent_acl_[dst_ip].insert(src_ip);
+            }
+        }
+
+        std::cout << "[Config] Loaded " << name_to_ip_.size() << " agent(s), "
+                  << agent_acl_.size() << " with agent ACLs, "
+                  << internet_acl_.size() << " with internet ACLs\n";
+
+        return true;
+    }
+
+    // ----- IP assignment lookups -----
+
+    std::string Config::find_agent_for_ip(uint32_t ipv4) const {
+        auto it = ip_to_name_.find(ipv4);
+        return (it != ip_to_name_.end()) ? it->second : "";
+    }
+
+    uint32_t Config::find_ip_for_agent(const std::string& name) const {
+        auto it = name_to_ip_.find(name);
+        return (it != name_to_ip_.end()) ? it->second : 0;
+    }
+
+    const std::unordered_map<std::string, uint32_t>& Config::agents() const {
+        return name_to_ip_;
+    }
+
+    // ----- ACL lookups -----
+
+    bool Config::can_agents_communicate(uint32_t src_ipv4, uint32_t dst_ipv4) const {
+        auto it = agent_acl_.find(src_ipv4);
+        if (it == agent_acl_.end()) return false;
+        return it->second.count(dst_ipv4) > 0;
+    }
+
+    bool Config::can_reach_internet_ip(uint32_t agent_ipv4, uint32_t internet_ipv4) const {
+        auto it = internet_acl_.find(agent_ipv4);
+        if (it == internet_acl_.end()) return false;
+        return it->second.count(internet_ipv4) > 0;
+    }
+
+    bool Config::has_any_internet_access(uint32_t agent_ipv4) const {
+        auto it = internet_acl_.find(agent_ipv4);
+        return it != internet_acl_.end() && !it->second.empty();
+    }
+
+};

--- a/src/blackbox/ipv4.cpp
+++ b/src/blackbox/ipv4.cpp
@@ -1,0 +1,55 @@
+#include "vnet/blackbox/ipv4.hpp"
+
+#include <cstring>
+
+namespace vnet::blackbox {
+
+    bool ipv4_parse(const uint8_t* data, size_t len, IPv4Header& out) {
+        // Minimum IPv4 header is 20 bytes
+        if (!data || len < 20)
+            return false;
+
+        out.version = (data[0] >> 4) & 0x0F;
+        out.ihl     = data[0] & 0x0F;
+
+        if (out.version != 4)
+            return false;
+        if (out.ihl < 5)
+            return false;
+
+        size_t ip_header_bytes = static_cast<size_t>(out.ihl) * 4;
+        if (len < ip_header_bytes)
+            return false;
+
+        // All multi-byte fields are stored in network byte order (memcpy).
+        std::memcpy(&out.total_length, data + 2, 2);
+        out.protocol = data[9];
+
+        // total_length is network order — convert to compare against buffer size
+        uint16_t total_host = static_cast<uint16_t>(
+            (data[2] << 8) | data[3]);
+        if (total_host > len)
+            return false;
+
+        // Source and destination IPs — network order
+        std::memcpy(&out.src_ip, data + 12, 4);
+        std::memcpy(&out.dst_ip, data + 16, 4);
+
+        // Extract transport-layer ports for TCP and UDP — network order
+        out.src_port = 0;
+        out.dst_port = 0;
+
+        if (out.protocol == PROTO_TCP || out.protocol == PROTO_UDP) {
+            // Need at least 4 bytes of transport header after the IP header
+            if (len < ip_header_bytes + 4)
+                return false;
+
+            const uint8_t* transport = data + ip_header_bytes;
+            std::memcpy(&out.src_port, transport, 2);
+            std::memcpy(&out.dst_port, transport + 2, 2);
+        }
+
+        return true;
+    }
+
+};

--- a/src/blackbox/routing_table.cpp
+++ b/src/blackbox/routing_table.cpp
@@ -1,0 +1,37 @@
+#include "vnet/blackbox/routing_table.hpp"
+
+#include <algorithm>
+
+namespace vnet::blackbox {
+
+    void RoutingTable::set_route(uint32_t dest_ipv4, int next_switch_fd) {
+        routes_[dest_ipv4] = next_switch_fd;
+    }
+
+    void RoutingTable::remove_route(uint32_t dest_ipv4) {
+        routes_.erase(dest_ipv4);
+    }
+
+    void RoutingTable::remove_routes_for_switch(int switch_fd) {
+        for (auto it = routes_.begin(); it != routes_.end(); ) {
+            if (it->second == switch_fd)
+                it = routes_.erase(it);
+            else
+                ++it;
+        }
+    }
+
+    int RoutingTable::lookup(uint32_t dest_ipv4) const {
+        auto it = routes_.find(dest_ipv4);
+        return (it != routes_.end()) ? it->second : -1;
+    }
+
+    size_t RoutingTable::size() const {
+        return routes_.size();
+    }
+
+    void RoutingTable::clear() {
+        routes_.clear();
+    }
+
+};

--- a/src/conductor/setup.cpp
+++ b/src/conductor/setup.cpp
@@ -1,7 +1,5 @@
 #include <iostream>
 #include <vector>
-#include <unordered_map>
-#include <mutex>
 #include <chrono>
 #include <random>
 #include <algorithm>
@@ -15,7 +13,6 @@
 #include <fcntl.h>
 
 #include "mip.pb.h"
-#include "common/config.h"
 #include "common/socket_utils.h"
 #include "vnet/protocol/dispatch.hpp"
 #include "vnet/netqueue/netqueue.hpp"
@@ -118,6 +115,11 @@ static ConductorState g_state;
 // ---------------------------------------------------------------------------
 
 struct ConductorDispatch : public Dispatch {
+    NetQueue* queue = nullptr;
+
+    void set_queue(NetQueue* q) {
+        queue = q;
+    }
 
     void onSwitchMIP(socket_data data, mip::PacketSwitchMIP& pkt) override {
         auto* info   = static_cast<ConnInfo*>(data.ptr_data);
@@ -155,6 +157,7 @@ struct ConductorDispatch : public Dispatch {
         if (!sw) {
             std::cerr << "[Conductor] No available switch for agent "
                       << pkt.name() << "\n";
+            queue->close(data.fd);
             return;
         }
 
@@ -170,13 +173,19 @@ struct ConductorDispatch : public Dispatch {
         resp.set_switch_ipv4(sw->sw_ipv4);
         resp.set_connection_token(token);
         resp.set_switch_port(sw->sw_port);
-        send_protobuf_packet(data.fd, PacketType::CONNECT_TO_SWITCH, resp);
+        if (!send_protobuf_packet(data.fd, PacketType::CONNECT_TO_SWITCH, resp)) {
+            std::cerr << "[Conductor] Failed to send switch assignment to agent " << pkt.name() << "\n";
+            return;
+        }
 
         // 2) Tell the switch to expect this agent (three-party handshake)
         mip::PacketAgentConnectionToken notify;
         notify.set_agent_name(pkt.name());
         notify.set_connection_token(token);
-        send_protobuf_packet(sw->fd, PacketType::AGENT_CONNECTION_TOKEN, notify);
+        if (!send_protobuf_packet(sw->fd, PacketType::AGENT_CONNECTION_TOKEN, notify)) {
+            std::cerr << "[Conductor] Failed to notify switch " << sw->name << " of agent " << pkt.name() << "\n";
+            return;
+        }
 
         g_state.agents.push_back(info);
     }
@@ -281,6 +290,7 @@ int main() {
     ConductorDispatch dispatch;
     NetworkQueueHandler handler = makeNetworkQueueHandler(&dispatch);
     NetQueue queue(handler, /*epoll_timeout_ms=*/200);
+    dispatch.set_queue(&queue);
 
     // --- Event loop ---
     while (g_running) {

--- a/src/conductor/setup.cpp
+++ b/src/conductor/setup.cpp
@@ -307,7 +307,7 @@ int main() {
             auto* info = new ConnInfo();
             info->fd = client;
 
-            if (!queue.put_sck(client, info)) {
+            if (queue.put_sck(client, info) == nullptr) {
                 std::cerr << "[Conductor] Failed to add fd " << client << " to queue\n";
                 close(client);
                 delete info;

--- a/src/netqueue/netqueue.cpp
+++ b/src/netqueue/netqueue.cpp
@@ -1,4 +1,3 @@
-
 #include "vnet/netqueue/netqueue.hpp"
 #include "vnet/protocol/header.hpp"
 

--- a/src/protocol/header.cpp
+++ b/src/protocol/header.cpp
@@ -1,13 +1,14 @@
 
 #include <arpa/inet.h>
 #include "vnet/protocol/header.hpp"
+#include "vnet/protocol/types.hpp"
 
 using namespace vnet::protocol;
 
-uint32_t PacketHeader::get_payload_size () {
+uint32_t PacketHeader::get_payload_size () const {
     return ntohl(payload_size);
 }
-PacketType PacketHeader::get_packet_type () {
+PacketType PacketHeader::get_packet_type () const {
     return ntoh_packet_type(packet_type);
 }
 

--- a/src/switch/setup.cpp
+++ b/src/switch/setup.cpp
@@ -17,6 +17,7 @@
 #include "mip.pb.h"
 #include "common/config.h"
 #include "common/socket_utils.h"
+#include "vnet/netqueue/handler.hpp"
 #include "vnet/protocol/dispatch.hpp"
 #include "vnet/netqueue/netqueue.hpp"
 
@@ -82,6 +83,11 @@ static SwitchState g_state;
 // ---------------------------------------------------------------------------
 
 struct SwitchDispatch : public Dispatch {
+    NetQueue* queue = nullptr;
+
+    void set_queue(NetQueue* q) {
+        queue = q;
+    }
 
     /*
      * Received from the conductor: a new agent is about to connect.
@@ -111,6 +117,7 @@ struct SwitchDispatch : public Dispatch {
         if (it == g_state.pending_tokens.end()) {
             std::cerr << "[Switch] Rejected agent: invalid token "
                       << token << "\n";
+            queue->close(data.fd);
             return;     // NetQueue will see no further reads → eventually close
         }
 
@@ -276,6 +283,7 @@ int main(int argc, char** argv) {
     SwitchDispatch dispatch;
     NetworkQueueHandler handler = makeNetworkQueueHandler(&dispatch);
     NetQueue queue(handler, /*epoll_timeout_ms=*/200);
+    dispatch.set_queue(&queue);
 
     // Add conductor connection to the queue
     auto* cdt_info = new ConnInfo();

--- a/src/switch/setup.cpp
+++ b/src/switch/setup.cpp
@@ -292,7 +292,7 @@ int main(int argc, char** argv) {
     cdt_info->fd   = cdt_sock;
     g_state.conductor = cdt_info;
 
-    if (!queue.put_sck(cdt_sock, cdt_info)) {
+    if (queue.put_sck(cdt_sock, cdt_info) == nullptr) {
         std::cerr << "[Switch] Failed to add conductor fd to queue\n";
         return 1;
     }
@@ -310,7 +310,7 @@ int main(int argc, char** argv) {
             info->role = ConnRole::AGENT_PENDING;
             info->fd   = agent_fd;
 
-            if (!queue.put_sck(agent_fd, info)) {
+            if (queue.put_sck(agent_fd, info) == nullptr) {
                 close(agent_fd);
                 delete info;
             }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,3 +26,16 @@ create_test(netqueue_tests        netqueue/netqueue_tests.cpp)
 
 # testing utils
 create_test(tun_wrapper_tests utils/tun_wrapper_tests.cpp)
+
+# testing vnet/blackbox
+function(create_blackbox_test test_name test_file)
+    add_executable(${test_name} ${test_file})
+    target_link_libraries(${test_name} PRIVATE vnet GTest::gtest_main)
+    gtest_discover_tests(${test_name})
+endfunction()
+
+create_blackbox_test(ipv4_tests             blackbox/ipv4_tests.cpp)
+create_blackbox_test(agent_registry_tests   blackbox/agent_registry_tests.cpp)
+create_blackbox_test(routing_table_tests    blackbox/routing_table_tests.cpp)
+create_blackbox_test(config_tests           blackbox/config_tests.cpp)
+create_blackbox_test(blackbox_tests         blackbox/blackbox_tests.cpp)

--- a/tests/blackbox/agent_registry_tests.cpp
+++ b/tests/blackbox/agent_registry_tests.cpp
@@ -1,0 +1,80 @@
+#include <gtest/gtest.h>
+#include "vnet/blackbox/agent_registry.hpp"
+
+#include <arpa/inet.h>
+
+using namespace vnet::blackbox;
+
+static uint32_t ip(const char* s) {
+    uint32_t addr = 0;
+    inet_pton(AF_INET, s, &addr);
+    return addr;
+}
+
+TEST(AgentRegistry, RegisterAndLookup) {
+    AgentRegistry reg;
+
+    auto* e = reg.register_agent("agent1", ip("10.0.1.1"), 5);
+    ASSERT_NE(e, nullptr);
+    EXPECT_EQ(e->name, "agent1");
+    EXPECT_EQ(e->virtual_ipv4, ip("10.0.1.1"));
+    EXPECT_EQ(e->fd, 5);
+
+    EXPECT_EQ(reg.find_by_ipv4(ip("10.0.1.1")), e);
+    EXPECT_EQ(reg.find_by_fd(5), e);
+    EXPECT_EQ(reg.find_by_name("agent1"), e);
+    EXPECT_EQ(reg.size(), 1u);
+}
+
+TEST(AgentRegistry, LookupMiss) {
+    AgentRegistry reg;
+    reg.register_agent("agent1", ip("10.0.1.1"), 5);
+
+    EXPECT_EQ(reg.find_by_ipv4(ip("10.0.1.2")), nullptr);
+    EXPECT_EQ(reg.find_by_fd(99), nullptr);
+    EXPECT_EQ(reg.find_by_name("nope"), nullptr);
+}
+
+TEST(AgentRegistry, UnregisterByFd) {
+    AgentRegistry reg;
+    reg.register_agent("agent1", ip("10.0.1.1"), 5);
+    reg.register_agent("agent2", ip("10.0.1.2"), 6);
+
+    reg.unregister_by_fd(5);
+
+    EXPECT_EQ(reg.find_by_fd(5), nullptr);
+    EXPECT_EQ(reg.find_by_ipv4(ip("10.0.1.1")), nullptr);
+    EXPECT_EQ(reg.find_by_name("agent1"), nullptr);
+    EXPECT_EQ(reg.size(), 1u);
+
+    EXPECT_NE(reg.find_by_fd(6), nullptr);
+}
+
+TEST(AgentRegistry, UnregisterByName) {
+    AgentRegistry reg;
+    reg.register_agent("agent1", ip("10.0.1.1"), 5);
+
+    reg.unregister_by_name("agent1");
+    EXPECT_EQ(reg.size(), 0u);
+    EXPECT_EQ(reg.find_by_fd(5), nullptr);
+}
+
+TEST(AgentRegistry, ReregisterSameName) {
+    AgentRegistry reg;
+    reg.register_agent("agent1", ip("10.0.1.1"), 5);
+    auto* e2 = reg.register_agent("agent1", ip("10.0.1.1"), 7);
+
+    EXPECT_EQ(reg.size(), 1u);
+    EXPECT_EQ(reg.find_by_fd(5), nullptr);
+    EXPECT_EQ(reg.find_by_fd(7), e2);
+}
+
+TEST(AgentRegistry, MultipleAgents) {
+    AgentRegistry reg;
+    reg.register_agent("a1", ip("10.0.1.1"), 10);
+    reg.register_agent("a2", ip("10.0.1.2"), 11);
+    reg.register_agent("a3", ip("10.0.1.3"), 12);
+
+    EXPECT_EQ(reg.size(), 3u);
+    EXPECT_EQ(reg.find_by_name("a2")->fd, 11);
+}

--- a/tests/blackbox/blackbox_tests.cpp
+++ b/tests/blackbox/blackbox_tests.cpp
@@ -1,0 +1,356 @@
+#include <gtest/gtest.h>
+#include "vnet/blackbox/blackbox.hpp"
+
+#include <fstream>
+#include <cstring>
+#include <arpa/inet.h>
+
+using namespace vnet::blackbox;
+
+static uint32_t ip(const char* s) {
+    uint32_t addr = 0;
+    inet_pton(AF_INET, s, &addr);
+    return addr;
+}
+
+static std::vector<uint8_t> make_packet(const char* src, const char* dst) {
+    std::vector<uint8_t> pkt(24, 0);
+    pkt[0] = 0x45;
+    uint16_t total = htons(24);
+    std::memcpy(pkt.data() + 2, &total, 2);
+    pkt[9] = PROTO_TCP;
+
+    uint32_t sip, dip;
+    inet_pton(AF_INET, src, &sip);
+    inet_pton(AF_INET, dst, &dip);
+    std::memcpy(pkt.data() + 12, &sip, 4);
+    std::memcpy(pkt.data() + 16, &dip, 4);
+
+    uint16_t sp = htons(1234), dp = htons(80);
+    std::memcpy(pkt.data() + 20, &sp, 2);
+    std::memcpy(pkt.data() + 22, &dp, 2);
+    return pkt;
+}
+
+class BlackBoxTest : public ::testing::Test {
+protected:
+    std::string tmp_path;
+    Config cfg;
+    static constexpr int TUN_FD = 100;
+
+    void write_config(const std::string& content) {
+        tmp_path = "/tmp/vnet_bb_test_" + std::to_string(getpid()) + ".conf";
+        std::ofstream f(tmp_path);
+        f << content;
+        f.close();
+    }
+
+    void SetUp() override {
+        write_config(
+            // IP assignments
+            "contestant1  10.0.1.1\n"
+            "contestant2  10.0.1.2\n"
+            "contestant3  10.0.1.3\n"
+            "gameserver   10.0.0.1\n"
+            "\n"
+            // ACL: contestants can talk to gameserver
+            "contestant1  gameserver\n"
+            "contestant2  gameserver\n"
+            // contestant3 has no rules at all
+            "\n"
+            // ACL: gameserver can reach specific internet IPs
+            "gameserver   ::internet:8.8.8.8\n"
+            "gameserver   ::internet:1.1.1.1\n"
+        );
+        ASSERT_TRUE(cfg.load(tmp_path));
+    }
+
+    void TearDown() override {
+        if (!tmp_path.empty()) std::remove(tmp_path.c_str());
+    }
+};
+
+// ----- Agent lifecycle -----
+
+TEST_F(BlackBoxTest, AgentRegistration) {
+    BlackBox box(cfg, TUN_FD);
+
+    EXPECT_TRUE(box.on_agent_authenticated("contestant1", 10));
+    EXPECT_TRUE(box.on_agent_authenticated("gameserver", 11));
+    EXPECT_EQ(box.agents().size(), 2u);
+}
+
+TEST_F(BlackBoxTest, AgentRegistrationUnknownName) {
+    BlackBox box(cfg, TUN_FD);
+    EXPECT_FALSE(box.on_agent_authenticated("nobody", 10));
+    EXPECT_EQ(box.agents().size(), 0u);
+}
+
+TEST_F(BlackBoxTest, AgentDisconnect) {
+    BlackBox box(cfg, TUN_FD);
+    box.on_agent_authenticated("contestant1", 10);
+
+    box.on_agent_disconnected(10);
+    EXPECT_EQ(box.agents().size(), 0u);
+}
+
+// ----- Source validation -----
+
+TEST_F(BlackBoxTest, SpoofedSource) {
+    BlackBox box(cfg, TUN_FD);
+    box.on_agent_authenticated("contestant1", 10);
+
+    auto pkt = make_packet("10.0.1.2", "10.0.0.1");
+    auto d = box.process(SourceType::AGENT, 10, pkt.data(), pkt.size());
+
+    EXPECT_EQ(d.action, PacketAction::DROP);
+    EXPECT_EQ(d.drop_reason, DropReason::SOURCE_SPOOF);
+}
+
+TEST_F(BlackBoxTest, UnknownSourceFd) {
+    BlackBox box(cfg, TUN_FD);
+
+    auto pkt = make_packet("10.0.1.1", "10.0.1.2");
+    auto d = box.process(SourceType::AGENT, 99, pkt.data(), pkt.size());
+
+    EXPECT_EQ(d.action, PacketAction::DROP);
+    EXPECT_EQ(d.drop_reason, DropReason::SOURCE_UNKNOWN);
+}
+
+// ----- ACL: agent-to-agent -----
+
+TEST_F(BlackBoxTest, ACLAllowedLocalDelivery) {
+    BlackBox box(cfg, TUN_FD);
+    box.on_agent_authenticated("contestant1", 10);
+    box.on_agent_authenticated("gameserver", 11);
+
+    // contestant1 → gameserver: allowed by ACL
+    auto pkt = make_packet("10.0.1.1", "10.0.0.1");
+    auto d = box.process(SourceType::AGENT, 10, pkt.data(), pkt.size());
+
+    EXPECT_EQ(d.action, PacketAction::DELIVER_LOCAL);
+    EXPECT_EQ(d.target_fd, 11);
+}
+
+TEST_F(BlackBoxTest, ACLAllowedReverse) {
+    BlackBox box(cfg, TUN_FD);
+    box.on_agent_authenticated("contestant1", 10);
+    box.on_agent_authenticated("gameserver", 11);
+
+    // gameserver → contestant1: allowed (bidirectional)
+    auto pkt = make_packet("10.0.0.1", "10.0.1.1");
+    auto d = box.process(SourceType::AGENT, 11, pkt.data(), pkt.size());
+
+    EXPECT_EQ(d.action, PacketAction::DELIVER_LOCAL);
+    EXPECT_EQ(d.target_fd, 10);
+}
+
+TEST_F(BlackBoxTest, ACLDeniedAgentToAgent) {
+    BlackBox box(cfg, TUN_FD);
+    box.on_agent_authenticated("contestant1", 10);
+    box.on_agent_authenticated("contestant2", 11);
+
+    // contestant1 → contestant2: NO ACL rule between them
+    auto pkt = make_packet("10.0.1.1", "10.0.1.2");
+    auto d = box.process(SourceType::AGENT, 10, pkt.data(), pkt.size());
+
+    EXPECT_EQ(d.action, PacketAction::DROP);
+    EXPECT_EQ(d.drop_reason, DropReason::ACL_DENIED);
+}
+
+TEST_F(BlackBoxTest, ACLDeniedIsolatedAgent) {
+    BlackBox box(cfg, TUN_FD);
+    box.on_agent_authenticated("contestant3", 12);
+    box.on_agent_authenticated("gameserver", 11);
+
+    // contestant3 has no rules at all
+    auto pkt = make_packet("10.0.1.3", "10.0.0.1");
+    auto d = box.process(SourceType::AGENT, 12, pkt.data(), pkt.size());
+
+    EXPECT_EQ(d.action, PacketAction::DROP);
+    EXPECT_EQ(d.drop_reason, DropReason::ACL_DENIED);
+}
+
+// ----- ACL: internet -----
+
+TEST_F(BlackBoxTest, InternetAllowedSpecificIP) {
+    BlackBox box(cfg, TUN_FD);
+    box.on_agent_authenticated("gameserver", 11);
+
+    // gameserver → 8.8.8.8: allowed
+    auto pkt = make_packet("10.0.0.1", "8.8.8.8");
+    auto d = box.process(SourceType::AGENT, 11, pkt.data(), pkt.size());
+
+    EXPECT_EQ(d.action, PacketAction::FORWARD_INTERNET);
+    EXPECT_EQ(d.target_fd, TUN_FD);
+}
+
+TEST_F(BlackBoxTest, InternetDeniedWrongIP) {
+    BlackBox box(cfg, TUN_FD);
+    box.on_agent_authenticated("gameserver", 11);
+
+    // gameserver → 9.9.9.9: NOT in ACL
+    auto pkt = make_packet("10.0.0.1", "9.9.9.9");
+    auto d = box.process(SourceType::AGENT, 11, pkt.data(), pkt.size());
+
+    EXPECT_EQ(d.action, PacketAction::DROP);
+    EXPECT_EQ(d.drop_reason, DropReason::ACL_DENIED);
+}
+
+TEST_F(BlackBoxTest, InternetDeniedNoRules) {
+    BlackBox box(cfg, TUN_FD);
+    box.on_agent_authenticated("contestant1", 10);
+
+    // contestant1 has no internet rules
+    auto pkt = make_packet("10.0.1.1", "8.8.8.8");
+    auto d = box.process(SourceType::AGENT, 10, pkt.data(), pkt.size());
+
+    EXPECT_EQ(d.action, PacketAction::DROP);
+    EXPECT_EQ(d.drop_reason, DropReason::ACL_DENIED);
+}
+
+TEST_F(BlackBoxTest, InternetNoTun) {
+    BlackBox box(cfg, -1);  // no TUN
+    box.on_agent_authenticated("gameserver", 11);
+
+    auto pkt = make_packet("10.0.0.1", "8.8.8.8");
+    auto d = box.process(SourceType::AGENT, 11, pkt.data(), pkt.size());
+
+    EXPECT_EQ(d.action, PacketAction::DROP);
+    EXPECT_EQ(d.drop_reason, DropReason::DEST_UNREACHABLE);
+}
+
+// ----- Remote routing -----
+
+TEST_F(BlackBoxTest, ForwardToSwitch) {
+    BlackBox box(cfg, TUN_FD);
+    box.on_agent_authenticated("contestant1", 10);
+
+    // contestant2 is known in config but not local, route exists
+    box.on_route_update(ip("10.0.1.2"), 20);
+
+    // contestant1 → contestant2: NOT allowed (no ACL between contestants)
+    auto pkt = make_packet("10.0.1.1", "10.0.1.2");
+    auto d = box.process(SourceType::AGENT, 10, pkt.data(), pkt.size());
+    EXPECT_EQ(d.action, PacketAction::DROP);
+    EXPECT_EQ(d.drop_reason, DropReason::ACL_DENIED);
+}
+
+TEST_F(BlackBoxTest, ForwardToSwitchAllowed) {
+    BlackBox box(cfg, TUN_FD);
+    box.on_agent_authenticated("contestant1", 10);
+
+    // gameserver is remote, route exists
+    box.on_route_update(ip("10.0.0.1"), 20);
+
+    // contestant1 → gameserver: allowed by ACL
+    auto pkt = make_packet("10.0.1.1", "10.0.0.1");
+    auto d = box.process(SourceType::AGENT, 10, pkt.data(), pkt.size());
+
+    EXPECT_EQ(d.action, PacketAction::FORWARD_SWITCH);
+    EXPECT_EQ(d.target_fd, 20);
+}
+
+TEST_F(BlackBoxTest, RequestRouteWhenUnknown) {
+    BlackBox box(cfg, TUN_FD);
+    box.on_agent_authenticated("contestant1", 10);
+
+    // gameserver is remote, no route set, but ACL allows
+    auto pkt = make_packet("10.0.1.1", "10.0.0.1");
+    auto d = box.process(SourceType::AGENT, 10, pkt.data(), pkt.size());
+
+    EXPECT_EQ(d.action, PacketAction::REQUEST_ROUTE);
+    EXPECT_EQ(d.dest_ipv4, ip("10.0.0.1"));
+}
+
+// ----- Packets from peer switch -----
+
+TEST_F(BlackBoxTest, SwitchDeliverLocal) {
+    BlackBox box(cfg, TUN_FD);
+    box.on_agent_authenticated("contestant1", 10);
+
+    auto pkt = make_packet("10.0.0.1", "10.0.1.1");
+    auto d = box.process(SourceType::SWITCH, 20, pkt.data(), pkt.size());
+
+    EXPECT_EQ(d.action, PacketAction::DELIVER_LOCAL);
+    EXPECT_EQ(d.target_fd, 10);
+}
+
+TEST_F(BlackBoxTest, SwitchDestNotLocal) {
+    BlackBox box(cfg, TUN_FD);
+
+    auto pkt = make_packet("10.0.0.1", "10.0.1.1");
+    auto d = box.process(SourceType::SWITCH, 20, pkt.data(), pkt.size());
+
+    EXPECT_EQ(d.action, PacketAction::DROP);
+    EXPECT_EQ(d.drop_reason, DropReason::DEST_UNREACHABLE);
+}
+
+// ----- Packets from TUN (internet return traffic) -----
+
+TEST_F(BlackBoxTest, TunReturnTrafficAllowed) {
+    BlackBox box(cfg, TUN_FD);
+    box.on_agent_authenticated("gameserver", 11);
+
+    // Return traffic from 8.8.8.8 → gameserver: allowed
+    auto pkt = make_packet("8.8.8.8", "10.0.0.1");
+    auto d = box.process(SourceType::TUN, TUN_FD, pkt.data(), pkt.size());
+
+    EXPECT_EQ(d.action, PacketAction::DELIVER_LOCAL);
+    EXPECT_EQ(d.target_fd, 11);
+}
+
+TEST_F(BlackBoxTest, TunReturnTrafficDenied) {
+    BlackBox box(cfg, TUN_FD);
+    box.on_agent_authenticated("gameserver", 11);
+
+    // Return traffic from 9.9.9.9: gameserver has no rule for this IP
+    auto pkt = make_packet("9.9.9.9", "10.0.0.1");
+    auto d = box.process(SourceType::TUN, TUN_FD, pkt.data(), pkt.size());
+
+    EXPECT_EQ(d.action, PacketAction::DROP);
+    EXPECT_EQ(d.drop_reason, DropReason::ACL_DENIED);
+}
+
+TEST_F(BlackBoxTest, TunDestNotLocal) {
+    BlackBox box(cfg, TUN_FD);
+
+    auto pkt = make_packet("8.8.8.8", "10.0.0.1");
+    auto d = box.process(SourceType::TUN, TUN_FD, pkt.data(), pkt.size());
+
+    EXPECT_EQ(d.action, PacketAction::DROP);
+    EXPECT_EQ(d.drop_reason, DropReason::DEST_UNREACHABLE);
+}
+
+// ----- Malformed packets -----
+
+TEST_F(BlackBoxTest, MalformedPacket) {
+    BlackBox box(cfg, TUN_FD);
+    box.on_agent_authenticated("contestant1", 10);
+
+    uint8_t garbage[5] = {0xFF, 0, 0, 0, 0};
+    auto d = box.process(SourceType::AGENT, 10, garbage, sizeof(garbage));
+
+    EXPECT_EQ(d.action, PacketAction::DROP);
+    EXPECT_EQ(d.drop_reason, DropReason::MALFORMED_PACKET);
+}
+
+// ----- Route cleanup -----
+
+TEST_F(BlackBoxTest, SwitchDisconnectClearsRoutes) {
+    BlackBox box(cfg, TUN_FD);
+    box.on_route_update(ip("10.0.1.2"), 20);
+    box.on_route_update(ip("10.0.0.1"), 20);
+
+    box.on_switch_disconnected(20);
+    EXPECT_EQ(box.routes().size(), 0u);
+}
+
+TEST_F(BlackBoxTest, RouteUpdateRemove) {
+    BlackBox box(cfg, TUN_FD);
+    box.on_route_update(ip("10.0.1.2"), 20);
+    EXPECT_EQ(box.routes().size(), 1u);
+
+    box.on_route_update(ip("10.0.1.2"), -1);
+    EXPECT_EQ(box.routes().size(), 0u);
+}

--- a/tests/blackbox/config_tests.cpp
+++ b/tests/blackbox/config_tests.cpp
@@ -1,0 +1,184 @@
+#include <gtest/gtest.h>
+#include "vnet/blackbox/config.hpp"
+
+#include <fstream>
+#include <arpa/inet.h>
+
+using namespace vnet::blackbox;
+
+static uint32_t ip(const char* s) {
+    uint32_t addr = 0;
+    inet_pton(AF_INET, s, &addr);
+    return addr;
+}
+
+class ConfigTest : public ::testing::Test {
+protected:
+    std::string tmp_path;
+
+    void write_config(const std::string& content) {
+        tmp_path = "/tmp/vnet_test_config_" + std::to_string(getpid()) + ".conf";
+        std::ofstream f(tmp_path);
+        f << content;
+        f.close();
+    }
+
+    void TearDown() override {
+        if (!tmp_path.empty()) {
+            std::remove(tmp_path.c_str());
+        }
+    }
+};
+
+TEST_F(ConfigTest, IPAssignments) {
+    write_config(
+        "agent1  10.0.1.1\n"
+        "agent2  10.0.1.2\n"
+    );
+
+    Config cfg;
+    ASSERT_TRUE(cfg.load(tmp_path));
+
+    EXPECT_EQ(cfg.find_agent_for_ip(ip("10.0.1.1")), "agent1");
+    EXPECT_EQ(cfg.find_agent_for_ip(ip("10.0.1.2")), "agent2");
+    EXPECT_EQ(cfg.find_ip_for_agent("agent1"), ip("10.0.1.1"));
+    EXPECT_EQ(cfg.agents().size(), 2u);
+}
+
+TEST_F(ConfigTest, AgentToAgentACL) {
+    write_config(
+        "agent1  10.0.1.1\n"
+        "agent2  10.0.1.2\n"
+        "agent3  10.0.1.3\n"
+        "\n"
+        "agent1  agent2\n"
+    );
+
+    Config cfg;
+    ASSERT_TRUE(cfg.load(tmp_path));
+
+    // Bidirectional
+    EXPECT_TRUE(cfg.can_agents_communicate(ip("10.0.1.1"), ip("10.0.1.2")));
+    EXPECT_TRUE(cfg.can_agents_communicate(ip("10.0.1.2"), ip("10.0.1.1")));
+
+    // No rule between agent1 and agent3
+    EXPECT_FALSE(cfg.can_agents_communicate(ip("10.0.1.1"), ip("10.0.1.3")));
+    EXPECT_FALSE(cfg.can_agents_communicate(ip("10.0.1.3"), ip("10.0.1.1")));
+
+    // No rule between agent2 and agent3
+    EXPECT_FALSE(cfg.can_agents_communicate(ip("10.0.1.2"), ip("10.0.1.3")));
+}
+
+TEST_F(ConfigTest, InternetACL) {
+    write_config(
+        "server  10.0.0.1\n"
+        "client  10.0.1.1\n"
+        "\n"
+        "server  ::internet:8.8.8.8\n"
+        "server  ::internet:1.1.1.1\n"
+    );
+
+    Config cfg;
+    ASSERT_TRUE(cfg.load(tmp_path));
+
+    EXPECT_TRUE(cfg.can_reach_internet_ip(ip("10.0.0.1"), ip("8.8.8.8")));
+    EXPECT_TRUE(cfg.can_reach_internet_ip(ip("10.0.0.1"), ip("1.1.1.1")));
+    EXPECT_FALSE(cfg.can_reach_internet_ip(ip("10.0.0.1"), ip("9.9.9.9")));
+
+    // Client has no internet rules
+    EXPECT_FALSE(cfg.can_reach_internet_ip(ip("10.0.1.1"), ip("8.8.8.8")));
+    EXPECT_FALSE(cfg.has_any_internet_access(ip("10.0.1.1")));
+    EXPECT_TRUE(cfg.has_any_internet_access(ip("10.0.0.1")));
+}
+
+TEST_F(ConfigTest, CommentsAndBlankLines) {
+    write_config(
+        "# This is a comment\n"
+        "\n"
+        "   # Indented comment\n"
+        "agent1  10.0.1.1\n"
+        "\n"
+    );
+
+    Config cfg;
+    ASSERT_TRUE(cfg.load(tmp_path));
+    EXPECT_EQ(cfg.agents().size(), 1u);
+}
+
+TEST_F(ConfigTest, UnknownAgent) {
+    write_config("agent1  10.0.1.1\n");
+
+    Config cfg;
+    ASSERT_TRUE(cfg.load(tmp_path));
+    EXPECT_EQ(cfg.find_agent_for_ip(ip("10.0.1.2")), "");
+    EXPECT_EQ(cfg.find_ip_for_agent("nope"), 0u);
+}
+
+TEST_F(ConfigTest, InvalidIPFails) {
+    write_config("agent1  not_an_ip\n");
+
+    Config cfg;
+    EXPECT_FALSE(cfg.load(tmp_path));
+}
+
+TEST_F(ConfigTest, DuplicateIPFails) {
+    write_config(
+        "agent1  10.0.1.1\n"
+        "agent2  10.0.1.1\n"
+    );
+
+    Config cfg;
+    EXPECT_FALSE(cfg.load(tmp_path));
+}
+
+TEST_F(ConfigTest, DuplicateNameFails) {
+    write_config(
+        "agent1  10.0.1.1\n"
+        "agent1  10.0.1.2\n"
+    );
+
+    Config cfg;
+    EXPECT_FALSE(cfg.load(tmp_path));
+}
+
+TEST_F(ConfigTest, ACLUnknownSourceFails) {
+    write_config(
+        "agent1  10.0.1.1\n"
+        "ghost   agent1\n"
+    );
+
+    Config cfg;
+    EXPECT_FALSE(cfg.load(tmp_path));
+}
+
+TEST_F(ConfigTest, ACLUnknownDestFails) {
+    write_config(
+        "agent1  10.0.1.1\n"
+        "agent1  ghost\n"
+    );
+
+    Config cfg;
+    EXPECT_FALSE(cfg.load(tmp_path));
+}
+
+TEST_F(ConfigTest, InternetBadIPFails) {
+    write_config(
+        "agent1  10.0.1.1\n"
+        "agent1  ::internet:not_an_ip\n"
+    );
+
+    Config cfg;
+    EXPECT_FALSE(cfg.load(tmp_path));
+}
+
+TEST_F(ConfigTest, MissingFileFails) {
+    Config cfg;
+    EXPECT_FALSE(cfg.load("/tmp/this_file_does_not_exist_12345.conf"));
+}
+
+TEST_F(ConfigTest, MalformedLineFails) {
+    write_config("agent1\n");
+
+    Config cfg;
+    EXPECT_FALSE(cfg.load(tmp_path));
+}

--- a/tests/blackbox/ipv4_tests.cpp
+++ b/tests/blackbox/ipv4_tests.cpp
@@ -1,0 +1,131 @@
+#include <gtest/gtest.h>
+#include "vnet/blackbox/ipv4.hpp"
+
+#include <cstring>
+#include <arpa/inet.h>
+
+using namespace vnet::blackbox;
+
+// Helper: build a minimal valid IPv4+TCP packet
+static std::vector<uint8_t> make_tcp_packet(
+    const char* src_ip, uint16_t src_port,
+    const char* dst_ip, uint16_t dst_port)
+{
+    // 20 bytes IP header + 4 bytes (ports only) of TCP
+    std::vector<uint8_t> pkt(24, 0);
+
+    pkt[0] = 0x45;  // version=4, ihl=5
+    uint16_t total = htons(24);
+    std::memcpy(pkt.data() + 2, &total, 2);
+    pkt[9] = PROTO_TCP;
+
+    uint32_t sip, dip;
+    inet_pton(AF_INET, src_ip, &sip);
+    inet_pton(AF_INET, dst_ip, &dip);
+    std::memcpy(pkt.data() + 12, &sip, 4);
+    std::memcpy(pkt.data() + 16, &dip, 4);
+
+    uint16_t sp = htons(src_port);
+    uint16_t dp = htons(dst_port);
+    std::memcpy(pkt.data() + 20, &sp, 2);
+    std::memcpy(pkt.data() + 22, &dp, 2);
+
+    return pkt;
+}
+
+TEST(IPv4Parser, ValidTCPPacket) {
+    auto pkt = make_tcp_packet("10.0.1.1", 12345, "10.0.1.2", 80);
+
+    IPv4Header hdr{};
+    ASSERT_TRUE(ipv4_parse(pkt.data(), pkt.size(), hdr));
+
+    EXPECT_EQ(hdr.version, 4);
+    EXPECT_EQ(hdr.ihl, 5);
+    EXPECT_EQ(hdr.protocol, PROTO_TCP);
+
+    char src_str[INET_ADDRSTRLEN], dst_str[INET_ADDRSTRLEN];
+    inet_ntop(AF_INET, &hdr.src_ip, src_str, sizeof(src_str));
+    inet_ntop(AF_INET, &hdr.dst_ip, dst_str, sizeof(dst_str));
+    EXPECT_STREQ(src_str, "10.0.1.1");
+    EXPECT_STREQ(dst_str, "10.0.1.2");
+
+    EXPECT_EQ(ntohs(hdr.src_port), 12345);
+    EXPECT_EQ(ntohs(hdr.dst_port), 80);
+}
+
+TEST(IPv4Parser, NullBuffer) {
+    IPv4Header hdr{};
+    EXPECT_FALSE(ipv4_parse(nullptr, 100, hdr));
+}
+
+TEST(IPv4Parser, TooShort) {
+    uint8_t buf[10] = {};
+    IPv4Header hdr{};
+    EXPECT_FALSE(ipv4_parse(buf, sizeof(buf), hdr));
+}
+
+TEST(IPv4Parser, WrongVersion) {
+    auto pkt = make_tcp_packet("10.0.0.1", 1, "10.0.0.2", 2);
+    pkt[0] = 0x65;  // version=6
+    IPv4Header hdr{};
+    EXPECT_FALSE(ipv4_parse(pkt.data(), pkt.size(), hdr));
+}
+
+TEST(IPv4Parser, IHLTooSmall) {
+    auto pkt = make_tcp_packet("10.0.0.1", 1, "10.0.0.2", 2);
+    pkt[0] = 0x43;  // version=4, ihl=3
+    IPv4Header hdr{};
+    EXPECT_FALSE(ipv4_parse(pkt.data(), pkt.size(), hdr));
+}
+
+TEST(IPv4Parser, TotalLengthExceedsBuffer) {
+    auto pkt = make_tcp_packet("10.0.0.1", 1, "10.0.0.2", 2);
+    // Set total_length to 1000, buffer is only 24
+    uint16_t big = htons(1000);
+    std::memcpy(pkt.data() + 2, &big, 2);
+    IPv4Header hdr{};
+    EXPECT_FALSE(ipv4_parse(pkt.data(), pkt.size(), hdr));
+}
+
+TEST(IPv4Parser, UDPPacket) {
+    auto pkt = make_tcp_packet("10.0.0.1", 5353, "10.0.0.2", 53);
+    pkt[9] = PROTO_UDP;
+    IPv4Header hdr{};
+    ASSERT_TRUE(ipv4_parse(pkt.data(), pkt.size(), hdr));
+    EXPECT_EQ(hdr.protocol, PROTO_UDP);
+    EXPECT_EQ(ntohs(hdr.src_port), 5353);
+    EXPECT_EQ(ntohs(hdr.dst_port), 53);
+}
+
+TEST(IPv4Parser, ICMPNoPorts) {
+    // ICMP: 20 byte IP header, no transport ports needed
+    std::vector<uint8_t> pkt(20, 0);
+    pkt[0] = 0x45;
+    uint16_t total = htons(20);
+    std::memcpy(pkt.data() + 2, &total, 2);
+    pkt[9] = PROTO_ICMP;
+
+    uint32_t sip, dip;
+    inet_pton(AF_INET, "10.0.0.1", &sip);
+    inet_pton(AF_INET, "10.0.0.2", &dip);
+    std::memcpy(pkt.data() + 12, &sip, 4);
+    std::memcpy(pkt.data() + 16, &dip, 4);
+
+    IPv4Header hdr{};
+    ASSERT_TRUE(ipv4_parse(pkt.data(), pkt.size(), hdr));
+    EXPECT_EQ(hdr.protocol, PROTO_ICMP);
+    EXPECT_EQ(hdr.src_port, 0);
+    EXPECT_EQ(hdr.dst_port, 0);
+}
+
+TEST(IPv4Parser, TCPMissingTransportHeader) {
+    // Only 20 bytes (IP header), but protocol is TCP → needs 4 more for ports
+    std::vector<uint8_t> pkt(20, 0);
+    pkt[0] = 0x45;
+    uint16_t total = htons(20);
+    std::memcpy(pkt.data() + 2, &total, 2);
+    pkt[9] = PROTO_TCP;
+
+    IPv4Header hdr{};
+    EXPECT_FALSE(ipv4_parse(pkt.data(), pkt.size(), hdr));
+}

--- a/tests/blackbox/routing_table_tests.cpp
+++ b/tests/blackbox/routing_table_tests.cpp
@@ -1,0 +1,66 @@
+#include <gtest/gtest.h>
+#include "vnet/blackbox/routing_table.hpp"
+
+#include <arpa/inet.h>
+
+using namespace vnet::blackbox;
+
+static uint32_t ip(const char* s) {
+    uint32_t addr = 0;
+    inet_pton(AF_INET, s, &addr);
+    return addr;
+}
+
+TEST(RoutingTable, SetAndLookup) {
+    RoutingTable rt;
+    rt.set_route(ip("10.0.1.1"), 7);
+
+    EXPECT_EQ(rt.lookup(ip("10.0.1.1")), 7);
+    EXPECT_EQ(rt.size(), 1u);
+}
+
+TEST(RoutingTable, LookupMiss) {
+    RoutingTable rt;
+    EXPECT_EQ(rt.lookup(ip("10.0.1.1")), -1);
+}
+
+TEST(RoutingTable, UpdateRoute) {
+    RoutingTable rt;
+    rt.set_route(ip("10.0.1.1"), 7);
+    rt.set_route(ip("10.0.1.1"), 8);
+
+    EXPECT_EQ(rt.lookup(ip("10.0.1.1")), 8);
+    EXPECT_EQ(rt.size(), 1u);
+}
+
+TEST(RoutingTable, RemoveRoute) {
+    RoutingTable rt;
+    rt.set_route(ip("10.0.1.1"), 7);
+    rt.remove_route(ip("10.0.1.1"));
+
+    EXPECT_EQ(rt.lookup(ip("10.0.1.1")), -1);
+    EXPECT_EQ(rt.size(), 0u);
+}
+
+TEST(RoutingTable, RemoveRoutesForSwitch) {
+    RoutingTable rt;
+    rt.set_route(ip("10.0.1.1"), 7);
+    rt.set_route(ip("10.0.1.2"), 7);
+    rt.set_route(ip("10.0.1.3"), 8);
+
+    rt.remove_routes_for_switch(7);
+
+    EXPECT_EQ(rt.lookup(ip("10.0.1.1")), -1);
+    EXPECT_EQ(rt.lookup(ip("10.0.1.2")), -1);
+    EXPECT_EQ(rt.lookup(ip("10.0.1.3")), 8);
+    EXPECT_EQ(rt.size(), 1u);
+}
+
+TEST(RoutingTable, Clear) {
+    RoutingTable rt;
+    rt.set_route(ip("10.0.1.1"), 7);
+    rt.set_route(ip("10.0.1.2"), 8);
+    rt.clear();
+
+    EXPECT_EQ(rt.size(), 0u);
+}


### PR DESCRIPTION
## Fix MIP handshake correctness issues

Three silent failure modes where connections would hang or fds would leak:

**1. Ignored send return values in `onAgentMIP` (conductor)**
Both `CONNECT_TO_SWITCH` and `AGENT_CONNECTION_TOKEN` sends had their return values discarded. If either failed, the agent blocked forever waiting for a switch assignment and the switch never learned about the incoming agent.

**2. Agent fd left open when no switch is available (conductor)**
When no switch was available, the handler returned without closing the agent fd. The agent blocked forever on `read_protobuf_packet` with no response coming.

**3. Invalid token fd leak (switch)**
On invalid token in `onAuthConnectToSwitch`, the handler returned silently. The fd stayed open indefinitely since epoll only closes on read errors or EOF — a connected silent fd triggers neither.

**Fix:** Both dispatch structs now hold a `NetQueue*` wired up via `set_queue()`. Send return values are checked and failures return early. Invalid token sets `SCK_ERROR` on the element so `wait_and_process` closes it via the normal `onClose` path.