### PR TITLE
Fix Nonblocking writes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 .vscode
 .DS_Store
 .idea
+compile_commands.json

--- a/include/vnet/netqueue/element.hpp
+++ b/include/vnet/netqueue/element.hpp
@@ -3,12 +3,16 @@
 
 #include <cstdint>
 #include <cstddef>
+#include <cstdlib>
+#include <vector>
 
 #include "vnet/const.hpp"
 #include "vnet/netqueue/fsm.hpp"
-#include <cstdlib>
 
 namespace vnet::netqueue {
+
+    static constexpr size_t WRITE_BUFFER_MAX = 65536; // 64KB
+
     struct NetworkElement {
         FiniteStateMachine state;
 
@@ -17,6 +21,9 @@ namespace vnet::netqueue {
 
         size_t net_buffer_used;
         uint8_t net_buffer[NET_BUFFER_SIZE];
+
+        std::vector<uint8_t> write_buffer;
+        size_t               write_buffer_offset = 0;
     
         NetworkElement (int fd, void *ptr, FiniteStateMachine state);
     };

--- a/include/vnet/netqueue/netqueue.hpp
+++ b/include/vnet/netqueue/netqueue.hpp
@@ -4,7 +4,9 @@
 #include "vnet/netqueue/fsm.hpp"
 #include "vnet/netqueue/element.hpp"
 #include "vnet/netqueue/handler.hpp"
+#include "vnet/protocol/types.hpp"
 
+#include <google/protobuf/message.h>
 #include <unordered_map>
 #include <mutex>
 
@@ -47,7 +49,42 @@ namespace vnet::netqueue {
          */
         NetworkQueueHandler handler;
 
+        /**
+        * Attempt to drain the write buffer for an element.
+        * Registers/deregisters EPOLLOUT as needed.
+        * Returns false if the connection should be closed.
+        */
+        bool flush_write_buffer(NetworkElement* element);
+
     public:
+
+        /**
+        * Send data to a file descriptor managed by this queue.
+        *
+        * If the kernel send buffer is full (EAGAIN), the remaining
+        * bytes are saved in the element's write buffer and sent when
+        * epoll signals the fd is writable (EPOLLOUT).
+        *
+        * If the write buffer exceeds WRITE_BUFFER_MAX the connection
+        * is closed and onClose is fired.
+        *
+        * @return true if all bytes were sent or buffered successfully.
+        *         false if the fd is not in the queue or the buffer limit
+        *         was exceeded (connection closed).
+        */
+        bool send(int fd, const void* data, size_t n);
+
+        /**
+        * Send a protobuf message with the 6-byte packet header
+        * through the queue's write path.
+        */
+        bool send(int fd, protocol::PacketType type, const google::protobuf::Message& msg);
+
+        /**
+        * Send a heartbeat (header-only) through the queue's write path.
+        */
+        bool send_heartbeat(int fd);
+
         /**
          * Put a file descriptor into the queue
          * with a pointer to some data the user wants

--- a/src/agent/setup.cpp
+++ b/src/agent/setup.cpp
@@ -76,11 +76,11 @@ struct AgentDispatch : public Dispatch {
 //  Heartbeat sender
 // ---------------------------------------------------------------------------
 
-static void send_heartbeats() {
+static void send_heartbeats(NetQueue& queue) {
     auto now = clk::now();
     auto try_hb = [&](ConnInfo* c) {
         if (c && c->fd >= 0 && now - c->last_hb_sent >= HEARTBEAT_INTERVAL) {
-            send_heartbeat(c->fd);
+            queue.send_heartbeat(c->fd);
             c->last_hb_sent = now;
         }
     };
@@ -239,7 +239,7 @@ int main(int argc, char** argv) {
 
     while (g_running) {
         queue.wait_and_process();
-        send_heartbeats();
+        send_heartbeats(queue);
     }
 
     std::cout << "[Agent] Shutting down.\n";

--- a/src/conductor/setup.cpp
+++ b/src/conductor/setup.cpp
@@ -157,7 +157,7 @@ struct ConductorDispatch : public Dispatch {
         if (!sw) {
             std::cerr << "[Conductor] No available switch for agent "
                       << pkt.name() << "\n";
-            queue.close(data.fd);
+            queue->close(data.fd);
             return;
         }
 
@@ -173,7 +173,7 @@ struct ConductorDispatch : public Dispatch {
         resp.set_switch_ipv4(sw->sw_ipv4);
         resp.set_connection_token(token);
         resp.set_switch_port(sw->sw_port);
-        if (!send_protobuf_packet(data.fd, PacketType::CONNECT_TO_SWITCH, resp)) {
+        if (!queue->send(data.fd, PacketType::CONNECT_TO_SWITCH, resp)) {
             std::cerr << "[Conductor] Failed to send switch assignment to agent " << pkt.name() << "\n";
             return;
         }
@@ -182,7 +182,7 @@ struct ConductorDispatch : public Dispatch {
         mip::PacketAgentConnectionToken notify;
         notify.set_agent_name(pkt.name());
         notify.set_connection_token(token);
-        if (!send_protobuf_packet(sw->fd, PacketType::AGENT_CONNECTION_TOKEN, notify)) {
+        if (!queue->send(sw->fd, PacketType::AGENT_CONNECTION_TOKEN, notify)) {
             std::cerr << "[Conductor] Failed to notify switch " << sw->name << " of agent " << pkt.name() << "\n";
             return;
         }
@@ -239,12 +239,12 @@ struct ConductorDispatch : public Dispatch {
 //  Heartbeat sender — called periodically from the main loop
 // ---------------------------------------------------------------------------
 
-static void send_heartbeats() {
+static void send_heartbeats(NetQueue& queue) {
     auto now = clk::now();
 
     auto try_hb = [&](ConnInfo* c) {
         if (now - c->last_hb_sent >= HEARTBEAT_INTERVAL) {
-            send_heartbeat(c->fd);
+            queue.send_heartbeat(c->fd);
             c->last_hb_sent = now;
         }
     };
@@ -318,7 +318,7 @@ int main() {
         queue.wait_and_process();
 
         // 3. Send heartbeats
-        send_heartbeats();
+        send_heartbeats(queue);
     }
 
     close(listener);

--- a/src/conductor/setup.cpp
+++ b/src/conductor/setup.cpp
@@ -1,7 +1,5 @@
 #include <iostream>
 #include <vector>
-#include <unordered_map>
-#include <mutex>
 #include <chrono>
 #include <random>
 #include <algorithm>
@@ -15,7 +13,6 @@
 #include <fcntl.h>
 
 #include "mip.pb.h"
-#include "common/config.h"
 #include "common/socket_utils.h"
 #include "vnet/protocol/dispatch.hpp"
 #include "vnet/netqueue/netqueue.hpp"
@@ -118,6 +115,11 @@ static ConductorState g_state;
 // ---------------------------------------------------------------------------
 
 struct ConductorDispatch : public Dispatch {
+    NetQueue* queue = nullptr;
+
+    void set_queue(NetQueue* q) {
+        queue = q;
+    }
 
     void onSwitchMIP(socket_data data, mip::PacketSwitchMIP& pkt) override {
         auto* info   = static_cast<ConnInfo*>(data.ptr_data);
@@ -155,6 +157,7 @@ struct ConductorDispatch : public Dispatch {
         if (!sw) {
             std::cerr << "[Conductor] No available switch for agent "
                       << pkt.name() << "\n";
+            queue.close(data.fd);
             return;
         }
 
@@ -170,13 +173,19 @@ struct ConductorDispatch : public Dispatch {
         resp.set_switch_ipv4(sw->sw_ipv4);
         resp.set_connection_token(token);
         resp.set_switch_port(sw->sw_port);
-        send_protobuf_packet(data.fd, PacketType::CONNECT_TO_SWITCH, resp);
+        if (!send_protobuf_packet(data.fd, PacketType::CONNECT_TO_SWITCH, resp)) {
+            std::cerr << "[Conductor] Failed to send switch assignment to agent " << pkt.name() << "\n";
+            return;
+        }
 
         // 2) Tell the switch to expect this agent (three-party handshake)
         mip::PacketAgentConnectionToken notify;
         notify.set_agent_name(pkt.name());
         notify.set_connection_token(token);
-        send_protobuf_packet(sw->fd, PacketType::AGENT_CONNECTION_TOKEN, notify);
+        if (!send_protobuf_packet(sw->fd, PacketType::AGENT_CONNECTION_TOKEN, notify)) {
+            std::cerr << "[Conductor] Failed to notify switch " << sw->name << " of agent " << pkt.name() << "\n";
+            return;
+        }
 
         g_state.agents.push_back(info);
     }
@@ -281,6 +290,7 @@ int main() {
     ConductorDispatch dispatch;
     NetworkQueueHandler handler = makeNetworkQueueHandler(&dispatch);
     NetQueue queue(handler, /*epoll_timeout_ms=*/200);
+    dispatch.set_queue(&queue);
 
     // --- Event loop ---
     while (g_running) {

--- a/src/netqueue/element.cpp
+++ b/src/netqueue/element.cpp
@@ -3,8 +3,9 @@
 
 using namespace vnet::netqueue;
 
-NetworkElement::NetworkElement (int fd, void *ptr, FiniteStateMachine state) {
-    this->net_buffer_used = 0;
+NetworkElement::NetworkElement(int fd, void* ptr, FiniteStateMachine state) {
+    this->net_buffer_used      = 0;
+    this->write_buffer_offset  = 0;
 
     this->fd    = fd;
     this->ptr   = ptr;

--- a/src/netqueue/netqueue.cpp
+++ b/src/netqueue/netqueue.cpp
@@ -1,4 +1,3 @@
-
 #include "vnet/netqueue/netqueue.hpp"
 #include "vnet/protocol/header.hpp"
 

--- a/src/netqueue/netqueue.cpp
+++ b/src/netqueue/netqueue.cpp
@@ -1,4 +1,5 @@
 #include "vnet/netqueue/netqueue.hpp"
+#include "vnet/netqueue/fsm.hpp"
 #include "vnet/protocol/header.hpp"
 
 #include <sys/epoll.h>
@@ -51,6 +52,108 @@ NetworkElement* NetQueue::put (int fd, void* data, FiniteStateMachine state) {
     return element;
 }
 
+bool NetQueue::flush_write_buffer(NetworkElement* element) {
+    auto& buf    = element->write_buffer;
+    auto& offset = element->write_buffer_offset;
+
+    while (offset < buf.size()) {
+        ssize_t r = ::write(element->fd,
+                            buf.data() + offset,
+                            buf.size() - offset);
+        if (r < 0) {
+            if (errno == EINTR) continue;
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                // Still can't write — keep EPOLLOUT registered
+                return true;
+            }
+            return false; // real error - caller should close
+        }
+        if (r == 0) return false;
+        offset += r;
+    }
+
+    // Buffer fully drained — clear it and remove EPOLLOUT
+    buf.clear();
+    offset = 0;
+
+    struct epoll_event ev;
+    ev.data.ptr = element;
+    ev.events   = EPOLLIN | EPOLLET | EPOLLONESHOT;
+    epoll_ctl(epoll_fd, EPOLL_CTL_MOD, element->fd, &ev);
+
+    return true;
+}
+
+bool NetQueue::send(int fd, const void* data, size_t n) {
+    NetworkElement* element = get_network_element_from_fd(fd);
+    if (!element) return false;
+
+    const uint8_t* ptr   = static_cast<const uint8_t*>(data);
+    size_t         total = 0;
+
+    // If there's already buffered data, append to it to preserve order
+    if (!element->write_buffer.empty()) {
+        size_t already_buffered = element->write_buffer.size()
+                                    - element->write_buffer_offset;
+        if (already_buffered + n > WRITE_BUFFER_MAX) {
+            element->state = SCK_ERROR;
+            return false;
+        }
+        element->write_buffer.insert(element->write_buffer.end(),
+                                     ptr, ptr + n);
+        return true;
+    }
+
+    // Try to write directly first
+    while (total < n) {
+        ssize_t r = ::write(fd, ptr + total, n - total);
+        if (r < 0) {
+            if (errno == EINTR) continue;
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                // Buffer the remainder
+                size_t remaining = n - total;
+                if (remaining > WRITE_BUFFER_MAX) {
+                    element->state = SCK_ERROR;
+                    return false;
+                }
+                element->write_buffer.assign(ptr + total, ptr + n);
+                element->write_buffer_offset = 0;
+
+                // Register EPOLLOUT
+                struct epoll_event ev;
+                ev.data.ptr = element;
+                ev.events   = EPOLLIN | EPOLLOUT | EPOLLET | EPOLLONESHOT;
+                epoll_ctl(epoll_fd, EPOLL_CTL_MOD, fd, &ev);
+
+                return true;
+            }
+            return false;
+        }
+        if (r == 0) return false;
+        total += r;
+    }
+    return true;
+}
+
+bool NetQueue::send(int fd, protocol::PacketType type,
+                    const google::protobuf::Message& msg) {
+    std::string body;
+    if (!msg.SerializeToString(&body)) return false;
+
+    protocol::PacketHeader hdr(static_cast<uint32_t>(body.size()), type);
+
+    if (!send(fd, &hdr, protocol::PACKET_HEADER_SIZE)) return false;
+    if (!body.empty()) {
+        if (!send(fd, body.data(), body.size())) return false;
+    }
+    return true;
+}
+
+bool NetQueue::send_heartbeat(int fd) {
+    protocol::PacketHeader hdr(0, protocol::PacketType::HEARTBEAT);
+    return send(fd, &hdr, protocol::PACKET_HEADER_SIZE);
+}
+
 NetQueue::NetQueue (NetworkQueueHandler handler) : NetQueue(handler, -1) {}
 NetQueue::NetQueue (NetworkQueueHandler handler, int epoll_timeout) {
     if (handler.onClose == nullptr || handler.onSocketReady == nullptr || handler.onTunReady == nullptr) {
@@ -93,6 +196,12 @@ void NetQueue::wait_and_process () {
                 reason = CLOSE_HANGUP;
             }
         }
+        if (events[i_event].events & EPOLLOUT) {
+            if (!flush_write_buffer(current_element)) {
+                should_close = true;
+                reason = CLOSE_ERROR;
+            }
+        }
         if (events[i_event].events & EPOLLERR) {
             should_close = true;
             reason = CLOSE_ERROR;
@@ -106,7 +215,9 @@ void NetQueue::wait_and_process () {
             struct epoll_event event;
             event.data.ptr = current_element;
             event.events   = EPOLLIN | EPOLLET | EPOLLONESHOT;
-        
+            if (!current_element->write_buffer.empty()) {
+                event.events |= EPOLLOUT;
+            }
             if (epoll_ctl(epoll_fd, EPOLL_CTL_MOD, current_element->fd, &event) < 0) {
                 should_close = true;
                 reason = CLOSE_EPOLL;

--- a/src/switch/setup.cpp
+++ b/src/switch/setup.cpp
@@ -17,6 +17,7 @@
 #include "mip.pb.h"
 #include "common/config.h"
 #include "common/socket_utils.h"
+#include "vnet/netqueue/handler.hpp"
 #include "vnet/protocol/dispatch.hpp"
 #include "vnet/netqueue/netqueue.hpp"
 
@@ -82,6 +83,11 @@ static SwitchState g_state;
 // ---------------------------------------------------------------------------
 
 struct SwitchDispatch : public Dispatch {
+    NetQueue* queue = nullptr;
+
+    void set_queue(NetQueue* q) {
+        queue = q;
+    }
 
     /*
      * Received from the conductor: a new agent is about to connect.
@@ -111,6 +117,7 @@ struct SwitchDispatch : public Dispatch {
         if (it == g_state.pending_tokens.end()) {
             std::cerr << "[Switch] Rejected agent: invalid token "
                       << token << "\n";
+            queue->close(data.fd);
             return;     // NetQueue will see no further reads → eventually close
         }
 
@@ -276,6 +283,7 @@ int main(int argc, char** argv) {
     SwitchDispatch dispatch;
     NetworkQueueHandler handler = makeNetworkQueueHandler(&dispatch);
     NetQueue queue(handler, /*epoll_timeout_ms=*/200);
+    dispatch.set_queue(&queue);
 
     // Add conductor connection to the queue
     auto* cdt_info = new ConnInfo();

--- a/src/switch/setup.cpp
+++ b/src/switch/setup.cpp
@@ -118,7 +118,7 @@ struct SwitchDispatch : public Dispatch {
             std::cerr << "[Switch] Rejected agent: invalid token "
                       << token << "\n";
             queue->close(data.fd);
-            return;     // NetQueue will see no further reads → eventually close
+            return;
         }
 
         info->role = ConnRole::AGENT_AUTHENTICATED;
@@ -129,7 +129,7 @@ struct SwitchDispatch : public Dispatch {
 
         // Send acceptance
         mip::PacketConnectionAccepted ack;
-        send_protobuf_packet(data.fd, PacketType::CONNECTION_ACCEPTED, ack);
+        queue->send(data.fd, PacketType::CONNECTION_ACCEPTED, ack);
 
         std::cout << "[Switch] Agent " << info->name
                   << " authenticated (fd=" << data.fd << ")\n";
@@ -163,11 +163,11 @@ struct SwitchDispatch : public Dispatch {
 //  Heartbeat sender
 // ---------------------------------------------------------------------------
 
-static void send_heartbeats() {
+static void send_heartbeats(NetQueue& queue) {
     auto now = clk::now();
     auto try_hb = [&](ConnInfo* c) {
         if (c && c->fd >= 0 && now - c->last_hb_sent >= HEARTBEAT_INTERVAL) {
-            send_heartbeat(c->fd);
+            queue.send_heartbeat(c->fd);
             c->last_hb_sent = now;
         }
     };
@@ -323,7 +323,7 @@ int main(int argc, char** argv) {
         g_state.expire_tokens();
 
         // Heartbeats
-        send_heartbeats();
+        send_heartbeats(queue);
     }
 
     close(listener);


### PR DESCRIPTION
## Add non-blocking write buffer to NetQueue

**Problem:** `write_n_bytes` spun with `usleep(200)` on EAGAIN. Since this runs inside dispatch handlers inside `wait_and_process`, send buffer pressure on any single connection stalled the entire event loop. Dropping on EAGAIN wasn't an option — losing `CONNECT_TO_SWITCH` or `AGENT_CONNECTION_TOKEN` breaks the handshake.

**Fix:** Each `NetworkElement` gets an outbound write buffer. On EAGAIN mid-write, remaining bytes are saved into the buffer and `EPOLLOUT` is registered on the fd. When the kernel send buffer drains, epoll fires and `flush_write_buffer` drains the queue. Once empty, `EPOLLOUT` is deregistered. Connections exceeding 64KB buffered are marked `SCK_ERROR` and closed on the next loop iteration — a connection that full isn't reading.

All in-loop sends in conductor, switch, and agent go through `queue->send` and `queue->send_heartbeat`. Blocking MIP phase sends stay on `send_protobuf_packet` since those fds aren't in the queue yet and are still in blocking mode.